### PR TITLE
decrease autocomplete delay to 100ms

### DIFF
--- a/home/templates/base_main.html
+++ b/home/templates/base_main.html
@@ -220,6 +220,7 @@
 
                 $("#header-search").autocomplete({
                     minLength: 3,
+                    delay: 100,
                     source: function(request, response) {
                         $.get("{% url 'autocomplete' %}", {"query": request.term, "types[]": ["professor", "course"], "return_attrs[]": ["url"]},  function(data) {
                             response(data);

--- a/home/templates/grades.html
+++ b/home/templates/grades.html
@@ -146,6 +146,7 @@
 	function initializeCourseSearchAutoComplete() {
 		$("#course-search").autocomplete({
 			minLength: 3,
+			delay: 100,
 			source: function(request, response) {
 				$.ajax({
 					url: "{% url 'autocomplete' %}",
@@ -170,6 +171,7 @@
 	function initializeProfessorSearchAutoComplete() {
 		$("#professor-search").autocomplete({
 			minLength: 3,
+			delay: 100,
 			source: function(request, response) {
 				$.ajax({
 					url: "{% url 'autocomplete' %}",

--- a/home/templates/index.html
+++ b/home/templates/index.html
@@ -113,6 +113,7 @@
 	$(document).ready(function() {
 		$("#main-search").autocomplete({
 			minLength: 3,
+			delay: 100,
 			source: function(request, response) {
 				$.get("{% url 'autocomplete' %}", {"query": request.term, "types[]": ["professor", "course"], "return_attrs[]": ["url"]}, function(data) {
 					response(data);


### PR DESCRIPTION
Was previously 300ms (the default). Master feels pretty bad right now in terms of how long you wait before results. Even though we're only cutting off 200ms, it still feels quite a bit better to me. Results in an average of twice the autocomplete calls when I try and type naturally, but those are relatively cheap since we're not rendering any templates.