### PR TITLE
Require course in review

### DIFF
--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -187,8 +187,11 @@ class ProfessorForm(Form):
 # The review form that contains fields specific to the review form
 class ProfessorFormReview(ProfessorForm):
     course = ChoiceField(
-        required=False,
-        label=False
+        required=True,
+        label=False,
+        error_messages={
+            "required": "You must select a course"
+        }
     )
 
     other_course = CharField(

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -279,9 +279,12 @@ class ProfessorFormAdd(ProfessorForm):
     )
 
     course = CharField(
-        required=False,
+        required=True,
         widget=TextInput,
-        label=False
+        label=False,
+        error_messages={
+            "required": "You must enter a course"
+        }
     )
 
     def __init__(self, user, **kwargs):


### PR DESCRIPTION
Once this PR is merged, users will be required to either select/input a course in their review. This change is beneficial because I believe that a course-less review is equivalent to not leaving a review in the first place. Our users want information pertaining to a professor for a particular course so why not ensure they get that. 

Unfortunately we won't be able to modify all course-less reviews from our database because we're not mind readers. This means `Review.course` will remain nullable at the model level, but at the validation level, empty course fields won't be accepted. 