### PR TITLE
fix current semester calculation for months >9

### DIFF
--- a/home/utils.py
+++ b/home/utils.py
@@ -69,14 +69,20 @@ class Semester:
     @staticmethod
     def current():
         now = datetime.now()
+        # spring (current year)
+        if now.month < 3:
+            semester = "01"
+            year = now.year
         # fall
         if 3 <= now.month <= 9:
             semester = "08"
-        # spring
+            year = now.year
+        # spring (of next year)
         else:
             semester = "01"
+            year = now.year + 1
 
-        return Semester(f"{now.year}{semester}")
+        return Semester(f"{year}{semester}")
 
     def name(self, *, year_first=False, short=False):
         year = self.year

--- a/home/utils.py
+++ b/home/utils.py
@@ -78,7 +78,7 @@ class Semester:
             semester = "08"
             year = now.year
         # spring (of next year)
-        if 10 < now.month:
+        if 9 < now.month:
             semester = "01"
             year = now.year + 1
 

--- a/home/utils.py
+++ b/home/utils.py
@@ -78,7 +78,7 @@ class Semester:
             semester = "08"
             year = now.year
         # spring (of next year)
-        else:
+        if 10 < now.month:
             semester = "01"
             year = now.year + 1
 


### PR DESCRIPTION
Previously we considered the current date (11/10/2022) to be spring 2022, when it should be spring 2023.