### PR TITLE
fix margin on sort buttons overflowing horizontally

### DIFF
--- a/home/templates/course_reviews.html
+++ b/home/templates/course_reviews.html
@@ -19,8 +19,8 @@
 
 {% if num_reviews > 0 %}
 	<div>
-		<div class="input-group ml-3">
-			<div class="input-group-prepend">
+		<div class="input-group">
+			<div class="input-group-prepend ml-3">
 				<label class="input-group-text" for="course-select" style="border-bottom-left-radius: 0;">Sort By:</label>
 			</div>
 

--- a/home/templates/professor.html
+++ b/home/templates/professor.html
@@ -69,8 +69,8 @@
 
 {% if num_reviews > 0 %}
 	<div>
-		<div class="input-group ml-3">
-			<div class="input-group-prepend">
+		<div class="input-group">
+			<div class="input-group-prepend ml-3">
 				<label class="input-group-text" for="course-select" style="border-bottom-left-radius: 0;">Sort By:</label>
 			</div>
 


### PR DESCRIPTION
Putting the margin on `input-group` (a flexbox) pushes it off scren horizontally and causes an annoying horizontal scroll bar to appear on all review pages. compare https://planetterp.com/professor/calderon_jose and local