### PR TITLE
change when the review_update webhook sends

### DIFF
--- a/home/utils.py
+++ b/home/utils.py
@@ -8,6 +8,7 @@ from threading import Thread
 from datetime import datetime
 
 from django.urls import reverse
+from django.template.defaultfilters import pluralize
 
 from discord_webhook import DiscordWebhook
 from discord_webhook.webhook import DiscordEmbed
@@ -204,22 +205,19 @@ def recompute_ttl_cache():
         value = (0, *values)
         _ttl_cache[key] = value
 
-def send_updates_webhook(request, *, include_professors=True, include_reviews=True):
+def send_updates_webhook(request):
     # avoid circular imports
     from home.models import Professor, Review
     if not WEBHOOK_URL_UPDATE:
         return
 
-    title = ""
     num_professors = Professor.pending.count()
     num_reviews = Review.pending.count()
 
-    if include_professors:
-        title += f"{num_professors} unverified professor(s)"
-    if include_professors and include_reviews:
-        title += " and "
-    if include_reviews:
-        title += f"{num_reviews} unverified review(s)"
+    title = f"{num_reviews} unverified review{pluralize(num_reviews)}"
+
+    if num_professors:
+        title += f" and {num_professors} unverified professor{pluralize(num_professors)}"
 
     webhook = DiscordWebhook(url=WEBHOOK_URL_UPDATE)
     embed = DiscordEmbed(title=title, description="\n",
@@ -227,7 +225,7 @@ def send_updates_webhook(request, *, include_professors=True, include_reviews=Tr
 
     webhook.add_embed(embed)
 
-    if (num_reviews + num_professors) % WEBHOOK_FREQUENCY != 0:
+    if num_reviews % WEBHOOK_FREQUENCY != 0:
         return
 
     webhook.execute()

--- a/home/views/professor.py
+++ b/home/views/professor.py
@@ -102,7 +102,7 @@ class Professor(View):
             new_review = Review(**review_data)
             new_review.save()
 
-            send_updates_webhook(request, include_professors=False)
+            send_updates_webhook(request)
 
             form = ProfessorFormReview(user, professor)
             context = {


### PR DESCRIPTION
OLD: the review_updates webhook would execute if `(Review.pending.count + Professor.pending.count) % WEBHOOK_FREQUENCY == 0`. This method would cause the webhook to execute inconsistently when users used the add_professor form because instead of increasing the count by 1, the count would increase by 2 which often skipped over numbers divisible by WEBHOOK_FREQUENCY. In other words, the sum in the above conditional statement would always be skewed by `Professor.pending.count` and never increased linearly. 

NEW: this PR would have the webhook execute if `Review.pending.count % WEBHOOK_FREQUENCY == 0`. Each time this code is called (in add_professor.py and professor.py), we compare the number of pending reviews and if there happens to be unverified professors when the message is getting ready to send, the message will indicate how many there are BUT this number doesn't affect when the message will send. Only the number of reviews affects that. 