### PR TITLE
Update importgradedata.py 

### DIFF
--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from django.db.models import Q
 from django.core.management import BaseCommand, CommandError
 
-from home.models import Professor, Course, Grade
+from home.models import Professor, Course, Grade, ProfessorAlias
 from home.utils import Semester
 
 class ValidationError(Exception):
@@ -82,6 +82,10 @@ class Command(BaseCommand):
         )
         if professors.exists():
             return professors.first()
+        # .first() is ok here because at most one record will be returned
+        alias = ProfessorAlias.objects.filter(alias=name.strip()).first()
+        if alias:
+            return alias.professor
 
         raise ValidationError("Professor doesn't exist")
 

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -87,10 +87,11 @@ class Command(BaseCommand):
 
         similar_professors = Professor.find_similar(name, 70)
         if professors.count() > 1 or len(similar_professors):
-            # if 'name' matches more than one professor or
-            # is similar to more than one professor, create a new
-            # unverified professor for us to manually decide
-            # which professor the data belongs to.
+            # if 'name' matches more than one professor or is similar to more
+            # than one professor, create a new pending professor for us to
+            # manually decide which professor the data belongs to.
+            # We'll go through the admin panel right after running this script
+            # to deal with any ambiguous professors.
             new_professor = Professor(
                 name=name,
                 type=Professor.Type.PROFESSOR

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -79,6 +79,8 @@ class Command(BaseCommand):
             return None
 
         name = name.strip()
+        lastname, firstname = name.split(", ")
+        name = f"{firstname.strip()} {lastname.strip()}"
 
         # .first() is ok here because at most one record will be returned
         alias = ProfessorAlias.objects.filter(alias=name).first()

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -88,7 +88,7 @@ class Command(BaseCommand):
             # if 'name' matches more than one professor or
             # is similar to more than one professor, create a new
             # unverified professor for us to manually decide
-            # which professor the data manually belongs to.
+            # which professor the data belongs to.
             new_professor = Professor(
                 name=name.strip(),
                 type=Professor.Type.PROFESSOR
@@ -97,7 +97,7 @@ class Command(BaseCommand):
             return new_professor
 
         raise ValidationError("Professor doesn't exist")
-        
+
 
     def add_grade(self, row):
         try:

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -74,23 +74,25 @@ class Command(BaseCommand):
         if name is None or name == "":
             return None
 
+        name = name.strip()
+
         # .first() is ok here because at most one record will be returned
-        alias = ProfessorAlias.objects.filter(alias=name.strip()).first()
+        alias = ProfessorAlias.objects.filter(alias=name).first()
         if alias:
             return alias.professor
 
-        professors = Professor.verified.filter(name=name.strip())
+        professors = Professor.verified.filter(name=name)
         if professors.count() == 1:
             return professors.first()
 
-        similar_professors = Professor.find_similar(name.strip(), 70)
+        similar_professors = Professor.find_similar(name, 70)
         if professors.count() > 1 or len(similar_professors):
             # if 'name' matches more than one professor or
             # is similar to more than one professor, create a new
             # unverified professor for us to manually decide
             # which professor the data belongs to.
             new_professor = Professor(
-                name=name.strip(),
+                name=name,
                 type=Professor.Type.PROFESSOR
             )
             new_professor.save()

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
         names = name.strip().split(",")
         lastname = names[0]
         firstname = names[-1].strip().split()[0]
-        professors = Professor.unfiltered.filter(
+        professors = Professor.verified.filter(
             Q(name__istartswith=firstname) & Q(name__iendswith=lastname)
         )
         if professors.exists():

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -80,8 +80,6 @@ class Command(BaseCommand):
             return alias.professor
 
         professors = Professor.verified.filter(name=name.strip())
-        if not professors.exists():
-            raise ValidationError("Professor doesn't exist")
         if professors.count() == 1:
             return professors.first()
 
@@ -97,6 +95,9 @@ class Command(BaseCommand):
             )
             new_professor.save()
             return new_professor
+
+        raise ValidationError("Professor doesn't exist")
+        
 
     def add_grade(self, row):
         try:

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -1,11 +1,16 @@
-# * Only CSV files are allowed!
+# Expected input is a csv file of grade data from umd.
 #
-# * Ensure that the grade data you're importing has the grade cutoffs listed as:
-#   A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F, W, OTHER
+# Before running:
+# * update professors and courses for any new entries
+# * ensure the spreadsheet has only the following grades listed, in this order:
+#   `A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F, W, OTHER`
+# * remove the header row at the top of the spreadsheet and check the data for
+#   invalid entries (at the bottom of the spreadsheet).
 #
-# * Remove column headers and check data for invalid entires (bottom of data)
-#
-# UPDATE COURSES AND PROFESSORS BEFORE RUNNING THIS SCRIPT
+# After running:
+# * go through /admin and deal with any ambiguous professors from the grade data
+#   - ie, determing which professor they actually map to and merge them into
+#   that professor.
 
 import csv
 from pathlib import Path

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -4,6 +4,8 @@
 #   A+, A, A-, B+, B, B-, C+, C, C-, D+, D, D-, F, W, OTHER
 #
 # * Remove column headers and check data for invalid entires (bottom of data)
+#
+# UPDATE COURSES AND PROFESSORS BEFORE RUNNING THIS SCRIPT
 
 import csv
 from pathlib import Path

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -71,7 +71,7 @@ class Command(BaseCommand):
         name = name.strip()
         courses = Course.unfiltered.filter(name=name)
         if not courses.exists():
-            raise ValidationError("Course doesn't exist")
+            raise ValidationError(f"Course {name} doesn't exist")
         return courses.get()
 
     def parse_professor(self, name: str):
@@ -105,7 +105,7 @@ class Command(BaseCommand):
             new_professor.save()
             return new_professor
 
-        raise ValidationError("Professor doesn't exist")
+        raise ValidationError(f"Professor {name} doesn't exist")
 
 
     def add_grade(self, row):

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -10,7 +10,6 @@
 import csv
 from pathlib import Path
 
-from django.db.models import Q
 from django.core.management import BaseCommand, CommandError
 
 from home.models import Professor, Course, Grade, ProfessorAlias

--- a/home/management/commands/importgradedata.py
+++ b/home/management/commands/importgradedata.py
@@ -90,7 +90,7 @@ class Command(BaseCommand):
             return professors.first()
 
         similar_professors = Professor.find_similar(name, 70)
-        if professors.count() > 1 or len(similar_professors):
+        if professors.count() > 1 or similar_professors:
             # if 'name' matches more than one professor or is similar to more
             # than one professor, create a new pending professor for us to
             # manually decide which professor the data belongs to.


### PR DESCRIPTION
Improves how importgradedata.py finds matching professors and handles situations where multiple professors are possible options. 7db31ca is gonna raise some eyebrows so allow me to explain my reasoning here:

This commit will create a new, unverified professor iff the name either exactly matches more than one professor in our database or the name is similar to more than professor in our database (via `Professor.find_similar()`). Initially, this script assumed the first professor is always the correct option which, along with the query used, created the possibility that a professor could be associated with incorrect data. 

We decided that we didn't want to verify new professors from the grade data and that will still be the case. Professors created from the grade data will have some similarity to other professors in our DB so verifying them in /admin will trigger the disambiguation screen where we select an existing professor to merge with. For these professors in particular, this will always be the case.

In addition to fixing the above issue, doing this will accumulate more aliases in ProfessorAlias.