### PR TITLE
change limit in docs to 100

### DIFF
--- a/api/static/openapi.yaml
+++ b/api/static/openapi.yaml
@@ -84,7 +84,7 @@ paths:
           schema:
             type: boolean
             default: false
-        - $ref: "#/components/parameters/limit-100-1000"
+        - $ref: "#/components/parameters/limit-100-100"
         - $ref: "#/components/parameters/offset"
       responses:
         '200':
@@ -160,7 +160,7 @@ paths:
           schema:
             type: boolean
             default: false
-        - $ref: "#/components/parameters/limit-100-1000"
+        - $ref: "#/components/parameters/limit-100-100"
         - $ref: "#/components/parameters/offset"
       responses:
         '200':
@@ -425,7 +425,7 @@ components:
         minimum: 1
         maximum: 100
         default: 30
-    limit-100-1000:
+    limit-100-100:
       in: query
       name: limit
       description: "Maximum number of records to return."
@@ -434,7 +434,7 @@ components:
       schema:
         type: integer
         minimum: 1
-        maximum: 1000
+        maximum: 100
         default: 100
     offset:
       in: query


### PR DESCRIPTION
I don't remember doing so, but the previous naming suggests this was an intentional decision. I'm going to veto my past self and say we probably don't want to expose a limit higher than 100 though (and certainly not as high as 1000). This might have made more sense back when we didn't calculate average gpa, which is expensive.

Closes #59 