### PR TITLE
Allow registered users to edit their reviews 

### DIFF
--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -85,7 +85,7 @@ class ProfessorForm(Form):
             "Submit",
             css_id=f"submit-{self.form_type.value}-form",
             css_class="btn-warning w-100 mt-3",
-            onClick=f'submitProfessorForm("#{self.form_html_id}")'
+            onClick=f'submitProfessorForm("#{self.form_html_id}", {self.form_type.value})'
         )
 
         rateYo = HTML(f'<div id="div_id_rating"><div id="rateYo_{self.form_type.value}" class="rateYo" class="p-0"></div></div>')
@@ -261,6 +261,11 @@ class ProfessorFormReview(ProfessorForm):
         return self.cleaned_data
 
 class ProfessorAndReviewForm(ProfessorForm):
+    form_type = CharField(
+        required=True,
+        widget=HiddenInput
+    )
+
     name = CharField(
         required=False,
         widget=TextInput,
@@ -322,6 +327,7 @@ class ProfessorFormAdd(ProfessorAndReviewForm):
     def __init__(self, user, **kwargs):
         super().__init__(user, Review.ReviewType.ADD, **kwargs)
         self.fields['type_'].choices = Professor.Type.choices
+        self.fields['form_type'].initial = Review.ReviewType.ADD.value
 
     def left_side_layout(self):
         name = Field('name', placeholder="Instructor Name", id=f"id_name_{self.form_type.value}")
@@ -344,6 +350,7 @@ class ProfessorFormAdd(ProfessorAndReviewForm):
     def generate_layout(self):
         layout = Layout(
             Modal(
+                'form_type',
                 super().generate_layout(),
                 css_id="add-professor-modal",
                 title_id="add-professor-label",
@@ -366,6 +373,7 @@ class ProfessorFormAdd(ProfessorAndReviewForm):
 class EditReviewForm(ProfessorAndReviewForm):
     def __init__(self, user, **kwargs):
         super().__init__(user, Review.ReviewType.EDIT, **kwargs)
+        self.fields['form_type'].initial = Review.ReviewType.EDIT.value
 
     def left_side_layout(self):
         name = Field('name', placeholder="Instructor Name", id=f"id_name_{self.form_type.value}")
@@ -384,6 +392,7 @@ class EditReviewForm(ProfessorAndReviewForm):
     def generate_layout(self):
         layout = Layout(
             Modal(
+                'form_type',
                 super().generate_layout(),
                 css_id="edit-professor-modal",
                 title_id="edit-professor-label",

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -285,9 +285,8 @@ class ProfessorAndReviewForm(ProfessorForm):
     def left_side_layout(self):
         pass
 
-    @abstractmethod
     def generate_layout(self):
-        pass
+        return super().generate_layout()
 
     def clean(self):
         super().clean()
@@ -317,11 +316,11 @@ class ProfessorFormAdd(ProfessorAndReviewForm):
     )
 
     def __init__(self, user, **kwargs):
-        super.__init__(user, Review.ReviewType.ADD, **kwargs)
+        super().__init__(user, Review.ReviewType.ADD, **kwargs)
         self.fields['type_'].choices = Professor.Type.choices
 
     def left_side_layout(self):
-        name = Field('name', placeholder="Instructor Name")
+        name = Field('name', placeholder="Instructor Name", id=f"id_name_{self.form_type.value}")
         name_errors = self.field_errors["name"]
 
         type_ = InlineRadios('type_')
@@ -360,13 +359,12 @@ class ProfessorFormAdd(ProfessorAndReviewForm):
 
         return self.cleaned_data
 
-
 class EditReviewForm(ProfessorAndReviewForm):
     def __init__(self, user, **kwargs):
-        super.__init__(user, Review.ReviewType.EDIT, **kwargs)
+        super().__init__(user, Review.ReviewType.EDIT, **kwargs)
 
     def left_side_layout(self):
-        name = Field('name', placeholder="Instructor Name")
+        name = Field('name', placeholder="Instructor Name", id=f"id_name_{self.form_type.value}")
         name_errors = self.field_errors["name"]
 
         course = Field(
@@ -385,6 +383,7 @@ class EditReviewForm(ProfessorAndReviewForm):
                 super().generate_layout(),
                 css_id="edit-professor-modal",
                 title_id="edit-professor-label",
+                title_class="w-100 text-center",
                 title="Edit your review below"
             )
         )

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -261,11 +261,6 @@ class ProfessorFormReview(ProfessorForm):
         return self.cleaned_data
 
 class ProfessorAndReviewForm(ProfessorForm):
-    form_type = CharField(
-        required=True,
-        widget=HiddenInput
-    )
-
     name = CharField(
         required=False,
         widget=TextInput,
@@ -327,7 +322,6 @@ class ProfessorFormAdd(ProfessorAndReviewForm):
     def __init__(self, user, **kwargs):
         super().__init__(user, Review.ReviewType.ADD, **kwargs)
         self.fields['type_'].choices = Professor.Type.choices
-        self.fields['form_type'].initial = Review.ReviewType.ADD.value
 
     def left_side_layout(self):
         name = Field('name', placeholder="Instructor Name", id=f"id_name_{self.form_type.value}")
@@ -350,7 +344,6 @@ class ProfessorFormAdd(ProfessorAndReviewForm):
     def generate_layout(self):
         layout = Layout(
             Modal(
-                'form_type',
                 super().generate_layout(),
                 css_id="add-professor-modal",
                 title_id="add-professor-label",
@@ -373,7 +366,6 @@ class ProfessorFormAdd(ProfessorAndReviewForm):
 class EditReviewForm(ProfessorAndReviewForm):
     def __init__(self, user, **kwargs):
         super().__init__(user, Review.ReviewType.EDIT, **kwargs)
-        self.fields['form_type'].initial = Review.ReviewType.EDIT.value
 
     def left_side_layout(self):
         name = Field('name', placeholder="Instructor Name", id=f"id_name_{self.form_type.value}")
@@ -392,7 +384,6 @@ class EditReviewForm(ProfessorAndReviewForm):
     def generate_layout(self):
         layout = Layout(
             Modal(
-                'form_type',
                 super().generate_layout(),
                 css_id="edit-professor-modal",
                 title_id="edit-professor-label",

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -277,9 +277,12 @@ class ProfessorAndReviewForm(ProfessorForm):
 
     def get_content_styles(self):
         if self.user.is_authenticated:
-            return "height: 15.8rem; margin: auto; border-bottom-left-radius: 0rem;"
-        else:
-            return "height: 18rem;"
+            styles = "margin: auto; border-bottom-left-radius: 0rem;"
+            if self.form_type is Review.ReviewType.ADD:
+                return "height: 15.8rem; " + styles
+            return "height: 13.2rem; " + styles
+
+        return "height: 18rem;"
 
     @abstractmethod
     def left_side_layout(self):

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -11,11 +11,8 @@ from django.utils.html import format_html
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Fieldset, Layout, Div, Field, HTML, Button
 from crispy_forms.bootstrap import FormActions, Alert, InlineRadios, Modal
-from discord_webhook import DiscordWebhook
-from discord_webhook.webhook import DiscordEmbed
 
 from home.models import Review, Professor, Course
-from planetterp import config
 
 class ProfessorForm(Form):
     grade = ChoiceField(

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -101,13 +101,6 @@ class ProfessorForm(Form):
         )
         content_errors = self.field_errors["content"]
 
-        success_banner = Div(
-            HTML('Review submitted successfully! <button type="button" class="close">&times;</button>'),
-            css_id=f"success-banner-{self.form_type.value}",
-            css_class="alert alert-dismissable alert-success text-center w-100 rounded-0 d-none position-absolute",
-            style="z-index: 1;"
-        )
-
         login_banner = None
         anonymous = None
 
@@ -131,7 +124,6 @@ class ProfessorForm(Form):
             )
 
         layout = Layout(
-            success_banner,
             login_banner,
             Fieldset(
                 None,
@@ -224,6 +216,19 @@ class ProfessorFormReview(ProfessorForm):
 
         left_side = (course, course_errors, other_course_container, 'slug')
         return left_side
+
+    def generate_layout(self):
+        success_banner = Div(
+            HTML('Review submitted successfully! <button type="button" class="close">&times;</button>'),
+            css_id=f"success-banner-{self.form_type.value}",
+            css_class="alert alert-dismissable alert-success text-center w-100 rounded-0 d-none position-absolute",
+            style="z-index: 1;"
+        )
+
+        return Layout(
+            success_banner,
+            super().generate_layout()
+        )
 
     def clean(self):
         super().clean()
@@ -340,8 +345,16 @@ class ProfessorFormAdd(ProfessorAndReviewForm):
         return left_side
 
     def generate_layout(self):
+        success_banner = Div(
+            HTML('Review submitted successfully! <button type="button" class="close">&times;</button>'),
+            css_id=f"success-banner-{self.form_type.value}",
+            css_class="alert alert-dismissable alert-success text-center rounded-0 d-none position-absolute",
+            style="z-index: 1;"
+        )
+
         layout = Layout(
             Modal(
+                success_banner,
                 super().generate_layout(),
                 css_id="add-professor-modal",
                 title_id="add-professor-label",

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -78,9 +78,12 @@ class ProfessorForm(Form):
         pass
 
     def generate_layout(self):
+        btn_name = ("submit", "Submit")
+        if self.form_type is Review.ReviewType.EDIT:
+            btn_name = ("update", "Update")
+
         submit_button = Button(
-            "submit",
-            "Submit",
+            *btn_name,
             css_id=f"submit-{self.form_type.value}-form",
             css_class="btn-warning w-100 mt-3",
             onClick=f'submitProfessorForm("#{self.form_html_id}", "{self.form_type.value}")'

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -359,7 +359,8 @@ class EditReviewForm(ProfessorForm):
     name = CharField(
         required=False,
         widget=TextInput,
-        label=False
+        label=False,
+        disabled=True
     )
 
     course = CharField(
@@ -377,7 +378,11 @@ class EditReviewForm(ProfessorForm):
         super().__init__(user, Review.ReviewType.EDIT, **kwargs)
 
     def left_side_layout(self):
-        name = Field('name', placeholder="Instructor Name", id=f"id_name_{self.form_type.value}")
+        name = Field(
+            'name',
+            placeholder="Instructor Name",
+            id=f"id_name_{self.form_type.value}"
+        )
         name_errors = self.field_errors["name"]
 
         course = Field(
@@ -408,13 +413,7 @@ class EditReviewForm(ProfessorForm):
     def clean(self):
         super().clean()
 
-        name = self.cleaned_data.get('name')
         course = self.cleaned_data.get('course')
-
-        if name == '' or name.isspace():
-            msg = "You must specify the instructor's name"
-            error = ValidationError(msg, code='Empty')
-            self.add_error("name", error)
 
         if course and not Course.unfiltered.filter(name=course).exists():
             error_msg = '''The course you specified is not in our database.

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -164,7 +164,8 @@ class ProfessorForm(Form):
         field_errors = {}
 
         for field in self.fields:
-            error_html = f'<div id="{{{{ form.{field}.name }}}}_errors" class="invalid-feedback text-center mb-3" style="font-size: 15px"></div>'
+            form_template_name = "form" if self.form_type is Review.ReviewType.ADD else f"{self.form_type.value}_form"
+            error_html = f'<div id="{{{{ {form_template_name}.{field}.name }}}}_errors" class="invalid-feedback text-center mb-3" style="font-size: 15px"></div>'
             field_errors[field] = HTML(error_html)
 
         return field_errors

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -78,8 +78,6 @@ class ProfessorForm(Form):
         pass
 
     def generate_layout(self):
-        # Ordering the fields/elements and assigning css styles
-        # https://django-crispy-forms.readthedocs.io/en/latest/layouts.html#universal-layout-objects
         submit_button = Button(
             "submit",
             "Submit",

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -139,7 +139,7 @@ class ProfessorForm(Form):
                     css_class="no_select review-left-wrapper"
                 ),
                 Div(
-                   content,
+                    content,
                     anonymous,
                     content_errors,
                     css_id=f"review-right-wrapper-{self.form_type.value}",

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -85,7 +85,7 @@ class ProfessorForm(Form):
             "Submit",
             css_id=f"submit-{self.form_type.value}-form",
             css_class="btn-warning w-100 mt-3",
-            onClick=f'submitProfessorForm("#{self.form_html_id}", {self.form_type.value})'
+            onClick=f'submitProfessorForm("#{self.form_html_id}", "{self.form_type.value}")'
         )
 
         rateYo = HTML(f'<div id="div_id_rating"><div id="rateYo_{self.form_type.value}" class="rateYo" class="p-0"></div></div>')

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -17,7 +17,6 @@ from discord_webhook.webhook import DiscordEmbed
 from home.models import Review, Professor, Course
 from planetterp import config
 
-# Base form that contains common form fields
 class ProfessorForm(Form):
     grade = ChoiceField(
         choices=[('', 'Expected Grade')] + Review.Grades.choices,
@@ -184,7 +183,6 @@ class ProfessorForm(Form):
 
         return cleaned_data
 
-# The review form that contains fields specific to the review form
 class ProfessorFormReview(ProfessorForm):
     course = ChoiceField(
         required=False,
@@ -311,7 +309,6 @@ class ProfessorAndReviewForm(ProfessorForm):
 
         return self.cleaned_data
 
-# The add professor/TA form that contains fields specific to the add professor/TA form
 class ProfessorFormAdd(ProfessorAndReviewForm):
     type_ = ChoiceField(
         required=False,

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -364,6 +364,8 @@ class ProfessorFormAdd(ProfessorAndReviewForm):
         return self.cleaned_data
 
 class EditReviewForm(ProfessorAndReviewForm):
+    review_id = IntegerField(required=True, widget=HiddenInput)
+
     def __init__(self, user, **kwargs):
         super().__init__(user, Review.ReviewType.EDIT, **kwargs)
 
@@ -384,6 +386,7 @@ class EditReviewForm(ProfessorAndReviewForm):
     def generate_layout(self):
         layout = Layout(
             Modal(
+                Field('review_id', id=f"review_id_{self.form_type.value}"),
                 super().generate_layout(),
                 css_id="edit-professor-modal",
                 title_id="edit-professor-label",

--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -386,7 +386,6 @@ class EditReviewForm(ProfessorAndReviewForm):
                 super().generate_layout(),
                 css_id="edit-professor-modal",
                 title_id="edit-professor-label",
-                title_class="w-100 text-center",
                 title="Edit your review below"
             )
         )

--- a/home/models.py
+++ b/home/models.py
@@ -408,6 +408,7 @@ class Review(Model):
     class ReviewType(Enum):
         ADD = "add"
         REVIEW = "review"
+        EDIT = "edit"
 
     class Grades(TextChoices):
         A_PLUS = ("A+", "A+")

--- a/home/tables/columns.py
+++ b/home/tables/columns.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date
 from abc import abstractmethod
 
@@ -10,7 +11,7 @@ from crispy_forms.utils import render_crispy_form
 import django_tables2 as tables
 
 from planetterp.settings import DATE_FORMAT
-from home.models import Review, Grade
+from home.models import Review, Grade, Course
 from home.forms.admin_forms import ReviewUnverifyForm
 
 class InformationColumn(tables.Column):
@@ -257,3 +258,21 @@ class UnverifiedProfessorsActionColumn(ActionColumn):
             "args": {"merge_subject": model_obj.name, "subject_id": model_obj.pk}
         }
         return format_html(column_html, **kwargs)
+
+class ProfileReviewsActionColumn(ActionColumn):
+    def render(self, value: dict):
+        request = value.pop("request")
+        model_obj = value.pop("model_obj")
+
+        ctx = {}
+        ctx.update(csrf(request))
+
+        review = {
+            "content": model_obj.content,
+            "rating": model_obj.rating,
+            "course": None if not model_obj.course_id else {"id": model_obj.course_id, "name": Course.unfiltered.get(pk=model_obj.course_id)},
+            "grade": None if not model_obj.grade else model_obj.grade
+        }
+
+        column_html = f'''<button class="btn btn-primary" onclick="editReview({json.dumps(review)})">Edit</button>'''
+        return mark_safe(column_html)

--- a/home/tables/columns.py
+++ b/home/tables/columns.py
@@ -2,7 +2,7 @@ import json
 from datetime import date
 from abc import abstractmethod
 
-from django.utils.html import format_html
+from django.utils.html import format_html, escape
 from django.utils.safestring import mark_safe
 from django.template.context_processors import csrf
 from django.urls import reverse
@@ -11,7 +11,7 @@ from crispy_forms.utils import render_crispy_form
 import django_tables2 as tables
 
 from planetterp.settings import DATE_FORMAT
-from home.models import Review, Grade, Course
+from home.models import Review, Grade, Course, Professor
 from home.forms.admin_forms import ReviewUnverifyForm
 
 class InformationColumn(tables.Column):
@@ -268,11 +268,13 @@ class ProfileReviewsActionColumn(ActionColumn):
         ctx.update(csrf(request))
 
         review = {
-            "content": model_obj.content,
+            "professor": escape(Professor.verified.get(pk=model_obj.professor_id).name),
+            "content": escape(model_obj.content),
             "rating": model_obj.rating,
-            "course": None if not model_obj.course_id else {"id": model_obj.course_id, "name": Course.unfiltered.get(pk=model_obj.course_id)},
+            "anonymous": model_obj.anonymous, 
+            "course": None if not model_obj.course_id else {"id": model_obj.course_id, "name": Course.unfiltered.get(pk=model_obj.course_id).name},
             "grade": None if not model_obj.grade else model_obj.grade
         }
 
-        column_html = f'''<button class="btn btn-primary" onclick="editReview({json.dumps(review)})">Edit</button>'''
+        column_html = f'''<button class="btn btn-primary" onclick='editReview({json.dumps(review)})'>Edit</button>'''
         return mark_safe(column_html)

--- a/home/tables/columns.py
+++ b/home/tables/columns.py
@@ -186,6 +186,9 @@ class ActionColumn(tables.Column):
         }
         super().__init__(verbose_name="Action", orderable=False, attrs=attrs, *args, **kwargs)
 
+    def header(self):
+        return ''
+
     @abstractmethod
     def render(self, value: dict):
         pass

--- a/home/tables/columns.py
+++ b/home/tables/columns.py
@@ -276,12 +276,12 @@ class ProfileReviewsActionColumn(ActionColumn):
 
         review = {
             "professor": escape(Professor.unfiltered.get(pk=model_obj.professor_id).name),
-            "content": escape(model_obj.content),
             "rating": model_obj.rating,
             "anonymous": model_obj.anonymous,
             "course": None if not model_obj.course_id else {"id": model_obj.course_id, "name": Course.unfiltered.get(pk=model_obj.course_id).name},
             "grade": None if not model_obj.grade else model_obj.grade,
-            "id": model_obj.pk
+            "id": model_obj.pk,
+            "content": escape(model_obj.content)
         }
 
         column_html = f'''<button id="update-{model_obj.pk}" class="btn btn-primary" onclick='editReview({json.dumps(review)})'>Edit</button>'''

--- a/home/tables/columns.py
+++ b/home/tables/columns.py
@@ -271,9 +271,10 @@ class ProfileReviewsActionColumn(ActionColumn):
             "professor": escape(Professor.verified.get(pk=model_obj.professor_id).name),
             "content": escape(model_obj.content),
             "rating": model_obj.rating,
-            "anonymous": model_obj.anonymous, 
+            "anonymous": model_obj.anonymous,
             "course": None if not model_obj.course_id else {"id": model_obj.course_id, "name": Course.unfiltered.get(pk=model_obj.course_id).name},
-            "grade": None if not model_obj.grade else model_obj.grade
+            "grade": None if not model_obj.grade else model_obj.grade,
+            "id": model_obj.pk
         }
 
         column_html = f'''<button class="btn btn-primary" onclick='editReview({json.dumps(review)})'>Edit</button>'''

--- a/home/tables/columns.py
+++ b/home/tables/columns.py
@@ -268,7 +268,7 @@ class ProfileReviewsActionColumn(ActionColumn):
         ctx.update(csrf(request))
 
         review = {
-            "professor": escape(Professor.verified.get(pk=model_obj.professor_id).name),
+            "professor": escape(Professor.unfiltered.get(pk=model_obj.professor_id).name),
             "content": escape(model_obj.content),
             "rating": model_obj.rating,
             "anonymous": model_obj.anonymous,

--- a/home/tables/columns.py
+++ b/home/tables/columns.py
@@ -146,7 +146,7 @@ class StatusColumn(tables.Column):
     def __init__(self, *args, **kwargs):
         attrs = {
             "th": {"class": "status"},
-            "td": {"class": "status"}
+            "td": {"class": "status w-100"}
         }
         super().__init__(verbose_name="Status", orderable=False, attrs=attrs, *args, **kwargs)
 

--- a/home/tables/reviews_table.py
+++ b/home/tables/reviews_table.py
@@ -39,7 +39,7 @@ class BaseReviewsTable(tables.Table):
         kwargs = {
             "exclude": [column.name.lower() for column in ReviewsTableColumn if column not in self.columns],
             "attrs": {"class": "table table-striped reviews-table"},
-            "sequence": (column.name.lower() for column in ReviewsTableColumn if column in self.columns),
+            "sequence": [column.name.lower() for column in self.columns],
             **kwargs
         }
 
@@ -63,13 +63,13 @@ class BaseReviewsTable(tables.Table):
                 }
             if ReviewsTableColumn.REVIEW in self.columns:
                 formatted_data['review'] = {"review": review}
-            if ReviewsTableColumn.STATUS in self.columns:
-                formatted_data['status'] = {"review": review}
             if ReviewsTableColumn.ACTION in self.columns:
                 formatted_data['action'] = {
                     "request": self.request,
                     "model_obj": review
                 }
+            if ReviewsTableColumn.STATUS in self.columns:
+                formatted_data['status'] = {"review": review}
 
             data.append(formatted_data)
         return data

--- a/home/tables/reviews_table.py
+++ b/home/tables/reviews_table.py
@@ -8,7 +8,7 @@ import django_tables2 as tables
 
 from home.utils import ReviewsTableColumn
 from home.models import Review
-from home.tables.columns import InformationColumn, ReviewColumn, StatusColumn, VerifiedReviewsActionColumn, UnverifiedReviewsActionColumn
+from home.tables.columns import InformationColumn, ReviewColumn, StatusColumn, VerifiedReviewsActionColumn, UnverifiedReviewsActionColumn, ProfileReviewsActionColumn
 
 class BaseReviewsTable(tables.Table):
     '''
@@ -104,9 +104,11 @@ class UnverifiedReviewsTable(BaseReviewsTable):
         super().__init__(self.columns, reviews, request, *args, **kwargs)
 
 class ProfileReviewsTable(BaseReviewsTable):
+    action = ProfileReviewsActionColumn()
+
     def __init__(self, reviews, request, *args, **kwargs):
         empty_text = mark_safe('<h4 class="text-center">You haven\'t written any reviews! Why not start now?</h4>')
-        self.columns = [ReviewsTableColumn.INFORMATION, ReviewsTableColumn.REVIEW, ReviewsTableColumn.STATUS]
+        self.columns = [ReviewsTableColumn.INFORMATION, ReviewsTableColumn.REVIEW, ReviewsTableColumn.ACTION, ReviewsTableColumn.STATUS]
 
         kwargs = {"empty_text": empty_text}
         super().__init__(self.columns, reviews, request, *args, **kwargs)

--- a/home/templates/professor.html
+++ b/home/templates/professor.html
@@ -63,7 +63,7 @@
 <div class="review-container mb-3" style="text-align: center;">
 	<button id="review-btn" class="btn btn-primary">Review this {{ professor.type }}</button>
 	<div id="review-form-container" style="display: none;">
-		{% crispy form %}
+		{% crispy review_form %}
 	</div>
 </div>
 

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -101,7 +101,7 @@
 		$("#rateYo_edit").rateYo("option", "rating", review["rating"]);
 
 		if (review["course"] != null)
-		$("#id_course_edit").val(review["course"]["name"]);
+			$("#id_course_edit").val(review["course"]["name"]);
 
 		$("#edit-professor-modal").modal('show');
 	}

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -101,6 +101,10 @@
 		$("#id_rating_edit").val(review["rating"]);
 		$("#rateYo_edit").rateYo("option", "rating", review["rating"]);
 
+		$("#edit-professor-modal div.invalid-feedback").hide();
+		$("#edit-professor-modal div.form-group .is-invalid").removeClass("is-invalid");
+		$("#id_content_edit").removeClass("is-invalid");
+
 		if (review["course"] != null)
 			$("#id_course_edit").val(review["course"]["name"]);
 

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -115,13 +115,12 @@
 		$("#id_rating_edit").val(review["rating"]);
 		$("#rateYo_edit").rateYo("option", "rating", review["rating"]);
 
-		$("#edit-professor-modal div.invalid-feedback").hide();
-		$("#edit-professor-modal div.form-group .is-invalid").removeClass("is-invalid");
-		$("#id_content_edit").removeClass("is-invalid");
-
 		if (review["course"] != null)
 			$("#id_course_edit").val(review["course"]["name"]);
 
+		$("#edit-professor-modal div.invalid-feedback").hide();
+		$("#edit-professor-modal div.form-group .is-invalid").removeClass("is-invalid");
+		$("#id_content_edit").removeClass("is-invalid");
 		$("#edit-professor-modal").modal('show');
 	}
 </script>

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -103,6 +103,8 @@
 	}
 
 	function editReview(review) {
+		var course_val = review["course"] == null ? '' : review["course"]["name"];
+
 		if (!$("#success-banner-edit").hasClass("d-none"))
 			$("#success-banner-edit").addClass("d-none");
 
@@ -115,8 +117,11 @@
 		$("#id_rating_edit").val(review["rating"]);
 		$("#rateYo_edit").rateYo("option", "rating", review["rating"]);
 
-		if (review["course"])
-			$("#id_course_edit").val(review["course"]["name"]);
+		$("#id_course_edit").val(course_val);
+		if (review["course"] != null)
+			$("#id_course_edit").prop("disabled", true);
+		else
+			$("#id_course_edit").prop("disabled", false);
 
 		$("#edit-professor-modal div.invalid-feedback").hide();
 		$("#edit-professor-modal div.form-group .is-invalid").removeClass("is-invalid");

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-{% crispy edit_review_form %}
+{% crispy edit_form %}
 
 <br />
 

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -6,6 +6,9 @@
 {% block description %}View your profile.{% endblock %}
 
 {% block content %}
+
+{% crispy edit_review_form %}
+
 <br />
 
 <ul class="nav nav-tabs" role="tablist">
@@ -19,9 +22,10 @@
 
 <div class="tab-content" id="profilePageContent">
 	<div class="tab-pane fade show active" id="reviews-noscroll" role="tabpanel" aria-labelledby="your-reviews-tab">
-	<h1 class="text-center my-4">Your Reviews</h1>
-	<div id="reviews-table-container" style="width: 80%; margin-left: auto; margin-right: auto; min-width: 600px; overflow-x: auto;">
-		{% render_table reviews_table %}
+		<h1 class="text-center my-4">Your Reviews</h1>
+		<div id="reviews-table-container" style="width: 80%; margin-left: auto; margin-right: auto; min-width: 600px; overflow-x: auto;">
+			{% render_table reviews_table %}
+		</div>
 	</div>
 </div>
 
@@ -49,7 +53,14 @@
 			$('.nav-tabs a[href="' + hash + '-noscroll"]').tab('show');
 		}
 
+		$("#professor-form-edit div.modal-lg").removeClass("modal-lg").addClass("modal-xl");
+		initializeRateYo(2.4, "edit");
 	});
+
+	$("#rateYo_edit").on('shown.bs.modal', function() {
+		setRateYoSize("#review-left-wrapper-edit", "#rateYo_edit");
+	});
+
 
 	// when a user changes tabs, change url hash as well
 	$('.nav-tabs a').on('shown.bs.tab', function (e) {
@@ -81,7 +92,18 @@
 	}
 
 	function editReview(review) {
+		$("#id_name_edit").val(review["professor"]);
+		$("#id_content_edit").val(review["content"]);
+		$("#id_grade_edit").val(review["grade"]);
+		$("#id_anonymous_edit").prop("checked", review["anonymous"]);
 
+		$("#id_rating_edit").val(review["rating"]);
+		$("#rateYo_edit").rateYo("option", "rating", review["rating"]);
+
+		if (review["course"] != null)
+		$("#id_course_edit").val(review["course"]["name"]);
+
+		$("#edit-professor-modal").modal('show');
 	}
 </script>
 {% endblock %}

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -92,6 +92,7 @@
 	}
 
 	function editReview(review) {
+		$("#review_id_edit").val(review["id"]);
 		$("#id_name_edit").val(review["professor"]);
 		$("#id_content_edit").val(review["content"]);
 		$("#id_grade_edit").val(review["grade"]);

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -79,5 +79,9 @@
 			}
 		});
 	}
+
+	function editReview(review) {
+
+	}
 </script>
 {% endblock %}

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -10,6 +10,17 @@
 {% crispy edit_form %}
 
 <br />
+<div id="success-banner-edit"  class="container fixed-top d-none" style="margin-top: 5rem;">
+	<div class="row">
+		<div class="col">
+			<div class="alert alert-dismissable alert-success text-center" style="margin-left: 12rem; margin-right: 12rem">
+				Review updated successfully! <button type="button" class="close">&times;</button>
+			</div>
+		</div>
+	</div>
+
+</div>
+
 
 <ul class="nav nav-tabs" role="tablist">
 	<li class="nav-item">
@@ -92,6 +103,9 @@
 	}
 
 	function editReview(review) {
+		if (!$("#success-banner-edit").hasClass("d-none"))
+			$("#success-banner-edit").addClass("d-none");
+
 		$("#review_id_edit").val(review["id"]);
 		$("#id_name_edit").val(review["professor"]);
 		$("#id_content_edit").val(review["content"]);

--- a/home/templates/profile.html
+++ b/home/templates/profile.html
@@ -115,7 +115,7 @@
 		$("#id_rating_edit").val(review["rating"]);
 		$("#rateYo_edit").rateYo("option", "rating", review["rating"]);
 
-		if (review["course"] != null)
+		if (review["course"])
 			$("#id_course_edit").val(review["course"]["name"]);
 
 		$("#edit-professor-modal div.invalid-feedback").hide();

--- a/home/templatetags/professor_form_add.py
+++ b/home/templatetags/professor_form_add.py
@@ -11,9 +11,9 @@ register = template.Library()
 def professor_form_add(context):
     request = context['request']
     user = request.user
-    form = ProfessorFormAdd(user)
+    add_form = ProfessorFormAdd(user)
     ctx = {}
     ctx.update(csrf(request))
 
     # https://django-crispy-forms.readthedocs.io/en/latest/crispy_tag_forms.html#render-a-form-within-python-code
-    return render_crispy_form(form, form.helper, context=ctx)
+    return render_crispy_form(add_form, add_form.helper, context=ctx)

--- a/home/urls.py
+++ b/home/urls.py
@@ -2,7 +2,7 @@ from django.urls import path, register_converter, reverse
 from django.contrib.sitemaps import Sitemap
 from django.contrib.sitemaps.views import sitemap
 
-from home.views.add_professor import AddProfessor
+from home.views.professor_review import AddProfessorAndReview, EditReview
 from home.views.admin import Admin
 from home.views.authentication import Login, Logout, ForgotPassword, Register
 from home.views.basic import (About, Contact, PrivacyPolicy, TermsOfUse,
@@ -129,7 +129,8 @@ urlpatterns = [
     path('course/<course:name>', Course.as_view(), name='course'),
     path('course/<course:name>/reviews', CourseReviews.as_view(), name='course-reviews'),
     path('admin', Admin.as_view(), name='admin'),
-    path('add_professor', AddProfessor.as_view(), name='add-professor'),
+    path('add_professor_and_review', AddProfessorAndReview.as_view(), name='add-professor'),
+    path('edit_review', EditReview.as_view(), name='edit-review'),
     path('grades', Grades.as_view(), name='grades'),
 
     # profile

--- a/home/views/professor.py
+++ b/home/views/professor.py
@@ -60,7 +60,7 @@ class Professor(View):
         context = {
             "user": user,
             "professor": professor,
-            "form": review_form,
+            "review_form": review_form,
             "courses_taught": courses_taught,
             "courses_reviewed": courses_reviewed,
             "courses_graded": courses_graded,

--- a/home/views/professor_review.py
+++ b/home/views/professor_review.py
@@ -5,7 +5,7 @@ from home.forms.professor_forms import ProfessorFormAdd
 from home.models import Professor, Review, Course
 from home.utils import send_updates_webhook
 
-class AddProfessor(View):
+class AddProfessorAndReview(View):
     def post(self, request):
         user = request.user
         form = ProfessorFormAdd(user, data=request.POST)
@@ -47,3 +47,6 @@ class AddProfessor(View):
             }
 
         return JsonResponse(context)
+
+class EditReview(View):
+    pass

--- a/home/views/profile.py
+++ b/home/views/profile.py
@@ -26,7 +26,7 @@ class Profile(LoginRequiredMixin, View):
         context = {
             "reviews_table": ProfileReviewsTable(reviews, request),
             "form": ProfileForm(instance=request.user),
-            "edit_review_form": EditReviewForm(request.user)
+            "edit_form": EditReviewForm(request.user)
         }
         return render(request, self.template, context)
 

--- a/home/views/profile.py
+++ b/home/views/profile.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http.response import HttpResponseBadRequest, JsonResponse
-from django.shortcuts import redirect, render
+from django.shortcuts import render
 from django.views import View
 from django.contrib.auth import login
 from django.template.context_processors import csrf

--- a/home/views/profile.py
+++ b/home/views/profile.py
@@ -10,6 +10,7 @@ from crispy_forms.utils import render_crispy_form
 from home.models import ResetCode
 from home.tables.reviews_table import ProfileReviewsTable
 from home.forms.basic import ProfileForm
+from home.forms.professor_forms import EditReviewForm
 from home.forms.auth_forms import ResetPasswordForm
 from planetterp.settings import DATE_FORMAT
 
@@ -24,7 +25,8 @@ class Profile(LoginRequiredMixin, View):
 
         context = {
             "reviews_table": ProfileReviewsTable(reviews, request),
-            "form": ProfileForm(instance=request.user)
+            "form": ProfileForm(instance=request.user),
+            "edit_review_form": EditReviewForm(request.user)
         }
         return render(request, self.template, context)
 

--- a/planetterp/static/js/professor-form.js
+++ b/planetterp/static/js/professor-form.js
@@ -82,9 +82,30 @@ function submitProfessorForm(form_id, form_type) {
                     $("#id_type__1").val("TA");
                 }
 
-                if (form_type == "edit")
-                    $("#edit-professor-modal").modal('hide');
+                if (form_type == "edit") {
+                    var review_id = data["id"];
+                    var anon_class = Boolean(data["anonymous"]) ? "fa fa-eye-slash" : "fa fa-eye";
 
+                    $(`#review-${review_id} td.review`).html(data["content"]);
+                    $(`#rating-${review_id}`).html(rating(Number(data["rating"])));
+                    $(`#grade-${review_id}`).html(grade(data["grade"]));
+                    $(`#anonymous-${review_id} i`).attr("class", anon_class);
+
+                    if (Boolean(data["unverify"]))
+                        $(`#status-${review_id}`).attr("css", {"color": "darkgoldenrod"}).html("Under Review");
+
+                    if (data["course"]) {
+                        var el = $(`#course-${review_id}`);
+                        el.html(course(data["course"]["name"]));
+                        if (el.parent().children().length % 2 != 0)
+                            el.after("<br />");
+                    }
+
+                    delete data["unverify"];
+                    delete data["success"];
+                    $(`#update-${review_id}`).attr("onclick", `editReview(${JSON.stringify(data)})`);
+                    $("#edit-professor-modal").modal('hide');
+                }
             }
         },
         error: function () {
@@ -93,3 +114,26 @@ function submitProfessorForm(form_id, form_type) {
         }
     });
 }
+
+function rating(rating) {
+    var rating_html = '';
+    for (let i = 0; i < rating; i++) {
+        rating_html += '<i style="margin-top:4px;" class="fas fa-star"></i>\n'
+        rating_html += '<i class="far fa-star"></i>\n'
+    }
+
+    for (let i = rating; i < 5; i++)
+        rating_html += '<i class="far fa-star"></i>\n'
+
+    return rating_html;
+}
+
+function grade(grade) {
+    var vowel_grades = ["A", "A-", "A+", "F", "XF"];
+    var a_str = (vowel_grades.includes(grade)) ? "an" : "a";
+    return `Expecting ${a_str} ${grade}`;
+ }
+
+ function course(course) {
+    return `<a href=/course/${course}>${course}</a>`;
+ }

--- a/planetterp/static/js/professor-form.js
+++ b/planetterp/static/js/professor-form.js
@@ -29,7 +29,7 @@ function submitProfessorForm(form_id) {
 
                 if (form_type == "add") {
                     delete field_mapping.other_course;
-                    field_mapping["name"] = "id_name";
+                    field_mapping["name"] = `id_name_${form_type}`;
 
                     if ("type_" in errors) {
                         $("#div_id_type_").addClass("mb-0");

--- a/planetterp/static/js/professor-form.js
+++ b/planetterp/static/js/professor-form.js
@@ -1,8 +1,8 @@
 function submitProfessorForm(form_id, form_type) {
     var url_mappings = {
         "review": "",
-        "add": "/add_professor",
-        "edit": "/add_professor"
+        "add": "/add_professor_and_review",
+        "edit": "/edit_review"
     }
 
     $.ajax({

--- a/planetterp/static/js/professor-form.js
+++ b/planetterp/static/js/professor-form.js
@@ -1,15 +1,13 @@
-function submitProfessorForm(form_id) {
-    if (form_id == '#professor-form-review') {
-        form_type = "review"
-        post_url = ""
-    } else {
-        form_type = "add"
-        post_url = "/add_professor"
+function submitProfessorForm(form_id, form_type) {
+    var url_mappings = {
+        "review": "",
+        "add": "/add_professor",
+        "edit": "/add_professor"
     }
 
     $.ajax({
         type: "POST",
-        url: post_url,
+        url: url_mappings[form_type],
         data: $(form_id).serialize(),
         success: function(data) {
             if (!(data['success'])) {

--- a/planetterp/static/js/professor-form.js
+++ b/planetterp/static/js/professor-form.js
@@ -81,6 +81,10 @@ function submitProfessorForm(form_id, form_type) {
                     $("#id_type__0").val("professor");
                     $("#id_type__1").val("TA");
                 }
+
+                if (form_type == "edit")
+                    $("#edit-professor-modal").modal('hide');
+
             }
         },
         error: function () {

--- a/planetterp/static/js/professor-form.js
+++ b/planetterp/static/js/professor-form.js
@@ -65,21 +65,19 @@ function submitProfessorForm(form_id, form_type) {
                 }
 
             } else {
-                if (form_type == "review") {
+                if (form_type == "review")
                     $(".anonymous-checkbox > div.form-group").addClass("mb-0");
-                }
+                else
+                    $(`#success-banner-${form_type}`).removeClass("w-100").css({"width": "69rem"});
 
-                $("div.invalid-feedback").hide();
-                $("div.form-group .is-invalid").removeClass("is-invalid");
+                $(`${form_id} div.invalid-feedback`).hide();
+                $(`${form_id} div.form-group .is-invalid`).removeClass("is-invalid");
 
-                if (form_type != "edit") {
-                    $(`#success-banner-${form_type}`).removeClass("d-none");
-                    $(':input', form_id).not(':button, :submit, :reset, :hidden').val('').prop('checked', false);
-                    $(`#rateYo_${form_type}`).rateYo("option", "rating", 0);
-                }
+                $(`#success-banner-${form_type}`).removeClass("d-none");
+                $(':input', form_id).not(':button, :submit, :reset, :hidden').val('').prop('checked', false);
+                $(`#rateYo_${form_type}`).rateYo("option", "rating", 0);
 
                 if (form_type == "add") {
-                    $("#success-banner-add").removeClass("w-100").css({"width": "69rem"});
                     $("#id_type__0").val("professor");
                     $("#id_type__1").val("TA");
                 }

--- a/planetterp/static/js/professor-form.js
+++ b/planetterp/static/js/professor-form.js
@@ -23,10 +23,12 @@ function submitProfessorForm(form_id) {
 
                 $(".anonymous-checkbox > div.form-group").addClass("mb-0");
 
-                if (form_type == "add") {
+                if (form_type != "review") {
                     delete field_mapping.other_course;
                     field_mapping["name"] = `id_name_${form_type}`;
+                }
 
+                if (form_type == "add") {
                     if ("type_" in errors) {
                         $("#div_id_type_").addClass("mb-0");
                         $("#type__errors").html(errors["type_"][0]["message"]);
@@ -72,9 +74,11 @@ function submitProfessorForm(form_id) {
                 $("div.invalid-feedback").hide();
                 $("div.form-group .is-invalid").removeClass("is-invalid");
 
-                $(`#success-banner-${form_type}`).removeClass("d-none");
-                $(':input', form_id).not(':button, :submit, :reset, :hidden').val('').prop('checked', false);
-                $(`#rateYo_${form_type}`).rateYo("option", "rating", 0);
+                if (form_type != "edit") {
+                    $(`#success-banner-${form_type}`).removeClass("d-none");
+                    $(':input', form_id).not(':button, :submit, :reset, :hidden').val('').prop('checked', false);
+                    $(`#rateYo_${form_type}`).rateYo("option", "rating", 0);
+                }
 
                 if (form_type == "add") {
                     $("#success-banner-add").removeClass("w-100").css({"width": "69rem"});

--- a/planetterp/static/js/professor-form.js
+++ b/planetterp/static/js/professor-form.js
@@ -65,6 +65,8 @@ function submitProfessorForm(form_id, form_type) {
                 }
 
             } else {
+                var show_banner = (form_type == "edit") ? data["has_changed"] : true;
+
                 if (form_type == "review")
                     $(".anonymous-checkbox > div.form-group").addClass("mb-0");
                 else
@@ -73,7 +75,9 @@ function submitProfessorForm(form_id, form_type) {
                 $(`${form_id} div.invalid-feedback`).hide();
                 $(`${form_id} div.form-group .is-invalid`).removeClass("is-invalid");
 
-                $(`#success-banner-${form_type}`).removeClass("d-none");
+                if (show_banner)
+                    $(`#success-banner-${form_type}`).removeClass("d-none");
+
                 $(':input', form_id).not(':button, :submit, :reset, :hidden').val('').prop('checked', false);
                 $(`#rateYo_${form_type}`).rateYo("option", "rating", 0);
 

--- a/planetterp/static/js/professor-form.js
+++ b/planetterp/static/js/professor-form.js
@@ -68,7 +68,7 @@ function submitProfessorForm(form_id, form_type) {
                 if (form_type == "review")
                     $(".anonymous-checkbox > div.form-group").addClass("mb-0");
                 else
-                    $(`#success-banner-${form_type}`).removeClass("w-100").css({"width": "69rem"});
+                    $(`#success-banner-${form_type}`).css({"width": "69rem"});
 
                 $(`${form_id} div.invalid-feedback`).hide();
                 $(`${form_id} div.form-group .is-invalid`).removeClass("is-invalid");

--- a/planetterp/static/js/professor-form.js
+++ b/planetterp/static/js/professor-form.js
@@ -1,14 +1,10 @@
 function submitProfessorForm(form_id) {
     if (form_id == '#professor-form-review') {
-        rateYo_multiplier = 3.1
         form_type = "review"
         post_url = ""
-        container_id = form_id;
     } else {
-        rateYo_multiplier = 1.8
         form_type = "add"
         post_url = "/add_professor"
-        container_id = "#add-professor-form-container";
     }
 
     $.ajax({


### PR DESCRIPTION
Registered users will be able to edit all aspects of a review except the professor's name and the course, if there is one. If there is no course, one can be added. 

If the content of the review (the text) is edited, then the review will be marked as pending for admins to approve. This applies to reviews with any status (verified, pending, rejected).  Any other edit aside from editing the text itself will be reflected immediately without the need for admins to approve. 