### PR TITLE
Improve courseupdate script

### DIFF
--- a/home/management/commands/updatecourses.py
+++ b/home/management/commands/updatecourses.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
             course_data = requests.get("https://api.umd.io/v1/courses", params=kwargs).json()
 
             # if no courses were found during semester, skip.
-            if "error_code" in course_data.keys():
+            if isinstance(course_data, dict) and 'error_code' in course_data.keys():
                 print(f"umd.io doesn't have data for {semester.name()}!")
                 continue
 

--- a/home/management/commands/updatecourses.py
+++ b/home/management/commands/updatecourses.py
@@ -108,9 +108,9 @@ class Command(BaseCommand):
             if professor.count() == 1:
                 professor = professor.first()
 
-            # if we have an alias for this name, use
-            # the professor associated with that alias.
-            elif professor.count() > 1 and alias.exists():
+            # if there are no matching professors but we have an alias
+            # for this name, use the professor associated with that alias.
+            elif professor.count() == 0 and alias.exists():
                 professor = alias.first()
 
             # Otherwise, we don't recognize this professor. So we

--- a/home/management/commands/updatecourses.py
+++ b/home/management/commands/updatecourses.py
@@ -113,9 +113,10 @@ class Command(BaseCommand):
             elif professor.count() == 0 and alias.exists():
                 professor = alias.first().professor
 
-            # Otherwise, we don't recognize this professor. So we
-            # create a new professor and attempt to automatically
-            # verify it following a process similar to that in admin.py.
+            # Otherwise, we either don't recognize this professor or there is
+            # more than one professor with this exact same name. So we create a
+            # new professor and attempt to automatically verify it following
+            # a process similar to that in admin.py.
             else:
                 professor = Professor(name=professor_name, type=Professor.Type.PROFESSOR)
                 similar_professors = Professor.find_similar(professor.name, 70)

--- a/home/management/commands/updatecourses.py
+++ b/home/management/commands/updatecourses.py
@@ -111,7 +111,7 @@ class Command(BaseCommand):
             # if there are no matching professors but we have an alias
             # for this name, use the professor associated with that alias.
             elif professor.count() == 0 and alias.exists():
-                professor = alias.first()
+                professor = alias.first().professor
 
             # Otherwise, we don't recognize this professor. So we
             # create a new professor and attempt to automatically

--- a/home/management/commands/updatecourses.py
+++ b/home/management/commands/updatecourses.py
@@ -108,10 +108,9 @@ class Command(BaseCommand):
             if professor.count() == 1:
                 professor = professor.first()
 
-            # if there's more than one matching professor but
-            # we have an alias that narrows the query down to one,
-            # use the professor associated with that alias.
-            elif professor.count() > 1 and alias.count() == 1:
+            # if we have an alias for this name, use
+            # the professor associated with that alias.
+            elif professor.count() > 1 and alias.exists():
                 professor = alias.first()
 
             # Otherwise, we don't recognize this professor. So we

--- a/home/management/commands/updatecourses.py
+++ b/home/management/commands/updatecourses.py
@@ -114,10 +114,9 @@ class Command(BaseCommand):
             elif professor.count() > 1 and alias.count() == 1:
                 professor = alias.first()
 
-            # Otherwise, we either don't have this professor or we couldn't
-            # narrow down the query enough. So, create a new professor and
-            # attempt to automatically verify it following a process similar
-            # to that in admin.py.
+            # Otherwise, we don't recognize this professor. So we
+            # create a new professor and attempt to automatically
+            # verify it following a process similar to that in admin.py.
             else:
                 professor = Professor(name=professor_name, type=Professor.Type.PROFESSOR)
                 similar_professors = Professor.find_similar(professor.name, 70)


### PR DESCRIPTION
This PR slightly improves the readability of the course update script and addresses some bugs. Specifically:
- originally, the alias would only be used if we had more than one professor with the same name and an alias existed. Instead,  we want to check for aliases if we don't have record of a professor and an alias exists. This meant that before this pr, if you updated courses for some semester then ran it again for the same semester, almost all the same professors that were unverified the first time were unverified the second time. With this pr, running the script on the same semester a second time wouldn't create any new courses or any* new professors. (*with the one exception where a semester has professors with the same name)
- assign professor variable a Professor object, not ProfessorAlias object
-  actually handle invalid UMD.io semesters 