### PR TITLE
Improve professor merging

### DIFF
--- a/home/views/admin.py
+++ b/home/views/admin.py
@@ -151,7 +151,8 @@ class Admin(UserPassesTestMixin, View):
 
         elif action_type is AdminAction.PROFESSOR_MERGE:
             subject_id = request.POST['subject_id']
-            merge_subject = Professor.unfiltered.get(pk=subject_id)
+            professors = Professor.unfiltered.exclude(staus=Professor.Status.REJECTED)
+            merge_subject = professors.get(pk=subject_id)
             form = ProfessorMergeForm(request, data=request.POST)
 
             ctx = {}
@@ -162,14 +163,18 @@ class Admin(UserPassesTestMixin, View):
 
             if form.is_valid():
                 target_id = form.cleaned_data['target_id']
-                merge_target = Professor.unfiltered.get(pk=target_id)
+                merge_target = professors.get(pk=target_id)
+                professor_courses = ProfessorCourse.objects.all()
+                reviews = Review.unfiltered.all()
+                grades = Grade.unfiltered.all()
+                professor_aliases = ProfessorAlias.objects.all()
 
-                ProfessorCourse.objects.filter(professor__id=subject_id).update(professor=merge_target)
-                Review.unfiltered.filter(professor__id=subject_id).update(professor=merge_target)
-                Grade.unfiltered.filter(professor__id=subject_id).update(professor=merge_target)
-                ProfessorAlias.objects.filter(professor=merge_subject).update(professor=merge_target)
+                professor_courses.filter(professor__id=subject_id).update(professor=merge_target)
+                reviews.filter(professor__id=subject_id).update(professor=merge_target)
+                grades.filter(professor__id=subject_id).update(professor=merge_target)
+                professor_aliases.filter(professor=merge_subject).update(professor=merge_target)
 
-                aliases = ProfessorAlias.objects.filter(alias=merge_subject.name, professor=merge_target)
+                aliases = professor_aliases.filter(alias=merge_subject.name, professor=merge_target)
                 if not aliases.exists():
                     ProfessorAlias(alias=merge_subject.name, professor=merge_target).save()
 

--- a/home/views/admin.py
+++ b/home/views/admin.py
@@ -175,7 +175,7 @@ class Admin(UserPassesTestMixin, View):
                 professor_aliases.filter(professor=merge_subject).update(professor=merge_target)
 
                 aliases = professor_aliases.filter(alias=merge_subject.name)
-                if not aliases.exists():
+                if not (aliases.exists() or professors.filter(name=merge_subject.name).count() > 1):
                     ProfessorAlias(alias=merge_subject.name, professor=merge_target).save()
 
                 context['success'] = True

--- a/home/views/admin.py
+++ b/home/views/admin.py
@@ -174,7 +174,7 @@ class Admin(UserPassesTestMixin, View):
                 grades.filter(professor__id=subject_id).update(professor=merge_target)
                 professor_aliases.filter(professor=merge_subject).update(professor=merge_target)
 
-                aliases = professor_aliases.filter(alias=merge_subject.name, professor=merge_target)
+                aliases = professor_aliases.filter(alias=merge_subject.name)
                 if not aliases.exists():
                     ProfessorAlias(alias=merge_subject.name, professor=merge_target).save()
 


### PR DESCRIPTION
Improvements include:
- Taking advantage of django caching by storing the many querysets in variables 
- When querying for existing aliases, don't filter on the professor. Only filter on the alias itself. Aliases are unique and therefore can't be duplicated at all
- Not creating aliases for professors who have the exact same name as other professors in the DB. For example, there are two professors named Douglas Hamilton, but they are different people. One teaches Astronomy and one teaches Physics. Since the names are identical, any aliases would likely be identical as well. This poses a problem because if an alias were given to, say, the Astronomy professor, then anytime you use that alias you're always gonna get Douglas Hamilton for Astronomy which might not be the professor you want. 
Don't fret though, I've ensured in other parts of the codebase that aliases are never used in this case so there's no harm if one of these professors did get an alias, but I'd rather not clutter the table. 