### PR TITLE
Improve courseupdate script.... again

### DIFF
--- a/home/management/commands/updatecourses.py
+++ b/home/management/commands/updatecourses.py
@@ -25,7 +25,6 @@ class Command(BaseCommand):
         super().__init__()
         self.total_num_new_courses = 0
         self.total_num_new_professors = 0
-        self.courses = Course.unfiltered.all()
         self.verified_professors = Professor.verified.all()
         self.non_rejected_professors = Professor.unfiltered.exclude(status=Professor.Status.REJECTED)
         self.aliases = ProfessorAlias.objects.all()
@@ -36,112 +35,73 @@ class Command(BaseCommand):
         parser.formatter_class = RawTextHelpFormatter
         return parser
 
-    def add_arguments(self, parser):
-        parser.add_argument("semesters", nargs='+')
-
     def handle(self, *args, **options):
         t_start = datetime.now()
-        semesters = [Semester(s) for s in options['semesters']]
-        print(f"Inputted Semesters: {', '.join(s.name() for s in semesters)}")
-
-        for semester in semesters:
-            kwargs = {"semester": semester, "per_page": 100, "page": 1}
-            course_data = requests.get("https://api.umd.io/v1/courses", params=kwargs).json()
-
-            # if no courses were found during semester, skip.
-            if isinstance(course_data, dict) and 'error_code' in course_data.keys():
-                print(f"umd.io doesn't have data for {semester.name()}!")
-                continue
-
-            print(f"Working on courses for {semester.name()}...")
-
-            while course_data:
-                # for every course taught during `semester`...
-                for umdio_course in course_data:
-                    course = self.courses.filter(name=umdio_course['course_id'].strip("\n\t\r ")).first()
-
-                    # if we don't have the course, create it.
-                    if not course:
-                        course = Course(
-                            name=umdio_course['course_id'].strip("\n\t\r "),
-                            department=umdio_course['dept_id'].strip("\n\t\r "),
-                            course_number=umdio_course['course_id'].strip("\n\t\r ")[4:],
-                            title=umdio_course['name'].strip("\n\t\r "),
-                            credits=umdio_course['credits'].strip("\n\t\r "),
-                            description=umdio_course["description"].strip("\n\t\r ")
-                        )
-
-                        course.save()
-                        self.total_num_new_courses += 1
-
-                    print(course)
-                    # collect all the professors that taught this course during `semester`
-                    self._professors(course, semester)
-
-                kwargs["page"] += 1
-                course_data = requests.get("https://api.umd.io/v1/courses", params=kwargs).json()
+        self._professors()
 
         print(f"\n** New Courses Created: {self.total_num_new_courses} **")
         print(f"** New Professors Created: {self.total_num_new_professors} **")
-
         runtime = datetime.now() - t_start
         print(f"Runtime: {round(runtime.seconds / 60, 2)} minutes")
 
-    def _professors(self, course: Course, semester: Semester):
-        kwargs = {"course_id": course.name}
+    def _professors(self):
+        kwargs = {"per_page": 100, "page": 1}
         umdio_professors = requests.get("https://api.umd.io/v1/professors", params=kwargs).json()
 
-        # if no professors were found for `course`, exit function.
-        if isinstance(umdio_professors, dict) and 'error_code' in umdio_professors.keys():
-            return
+        while umdio_professors:
+            for umdio_professor in umdio_professors:
+                professor_name = umdio_professor['name'].strip("\n\t\r ")
+                if re.search("instructor:?\s*tba", professor_name.lower()):
+                    continue
 
-        # for every professor that taught `course`...
-        for umdio_professor in umdio_professors:
-            professor_name = umdio_professor['name'].strip("\n\t\r ")
-            if re.search("instructor:?\s*tba", professor_name.lower()):
-                continue
+                print(professor_name)
 
-            professor = self.non_rejected_professors.filter(name=professor_name)
-            alias = self.aliases.filter(alias=professor_name)
+                professor = self.non_rejected_professors.filter(name=professor_name)
+                alias = self.aliases.filter(alias=professor_name)
 
-            # if there's only one matching professor, use that professor.
-            if professor.count() == 1:
-                professor = professor.first()
+                # if there's only one matching professor, use that professor.
+                if professor.count() == 1:
+                    professor = professor.first()
 
-            # if there are no matching professors but we have an alias
-            # for this name, use the professor associated with that alias.
-            elif professor.count() == 0 and alias.exists():
-                professor = alias.first().professor
+                # if there are no matching professors but we have an alias
+                # for this name, use the professor associated with that alias.
+                elif professor.count() == 0 and alias.exists():
+                    professor = alias.first().professor
 
-            # Otherwise, we either don't recognize this professor or there is
-            # more than one professor with this exact same name. So we create a
-            # new professor and attempt to automatically verify it following
-            # a process similar to that in admin.py.
-            else:
-                professor = Professor(name=professor_name, type=Professor.Type.PROFESSOR)
-                similar_professors = Professor.find_similar(professor.name, 70)
-                split_name = professor.name.strip().split()
-                new_slug = split_name[-1].lower()
-                valid_slug = True
+                # Otherwise, we either don't recognize this professor or there is
+                # more than one professor with this exact same name. So we create a
+                # new professor and attempt to automatically verify it following
+                # a process similar to that in admin.py.
+                else:
+                    professor = Professor(name=professor_name, type=Professor.Type.PROFESSOR)
+                    similar_professors = Professor.find_similar(professor.name, 70)
+                    split_name = professor.name.strip().split()
+                    new_slug = split_name[-1].lower()
+                    valid_slug = True
 
-                if self.verified_professors.filter(slug=new_slug).exists():
-                    new_slug = f"{split_name[-1]}_{split_name[0]}".lower()
                     if self.verified_professors.filter(slug=new_slug).exists():
-                        valid_slug = False
+                        new_slug = f"{split_name[-1]}_{split_name[0]}".lower()
+                        if self.verified_professors.filter(slug=new_slug).exists():
+                            valid_slug = False
 
-                # if there are no similarly named professors and there's no
-                # issues with the auto generated slug, verify the professor.
-                if len(similar_professors) == 0 and valid_slug:
-                    professor.slug = new_slug
-                    professor.status = Professor.Status.VERIFIED
+                    # if there are no similarly named professors and there's no
+                    # issues with the auto generated slug, verify the professor.
+                    if len(similar_professors) == 0 and valid_slug:
+                        professor.slug = new_slug
+                        professor.status = Professor.Status.VERIFIED
 
-                professor.save()
-                self.total_num_new_professors += 1
+                    professor.save()
+                    self.total_num_new_professors += 1
 
-            # for every course taught by `professor`...
-            for entry in umdio_professor['taught']:
-                # we only care about `course` taught during `semester`.
-                if entry['course_id'] == course.name and Semester(entry['semester']) == semester:
+                # for every course taught by `professor`...
+                for entry in umdio_professor['taught']:
+                    semester_taught = Semester(entry['semester'])
+                    clean_course_name = entry['course_id'].strip("\n\t\r ")
+                    course = self.get_or_create_course(clean_course_name)
+
+                    if not course:
+                        continue
+
                     professorcourse = self.professor_courses.filter(
                         course=course,
                         professor=professor
@@ -150,12 +110,38 @@ class Command(BaseCommand):
                     # if only one professorcourse record and it doesn't
                     # have a recent semester, update that one record.
                     if professorcourse.count() == 1 and not professorcourse.first().recent_semester:
-                        professorcourse.update(recent_semester=semester)
+                        professorcourse.update(recent_semester=semester_taught)
 
                     # if there's no professorcourse entries at all that match
                     # the prof/course combo or if there are matching records but
                     # none of them have recent semester = `semester`, create a new
                     # professor course entry.
-                    elif professorcourse.count() == 0 or not professorcourse.filter(recent_semester=semester).exists():
-                        ProfessorCourse.objects.create(course=course, professor=professor, recent_semester=semester)
-                    break
+                    elif professorcourse.count() == 0 or not professorcourse.filter(recent_semester=semester_taught).exists():
+                        ProfessorCourse.objects.create(course=course, professor=professor, recent_semester=semester_taught)
+
+            kwargs["page"] += 1
+            umdio_professors = requests.get("https://api.umd.io/v1/professors", params=kwargs).json()
+
+    def get_or_create_course(self, course_name):
+        course = Course.unfiltered.filter(name=course_name).first()
+
+        if not course:
+            umdio_course = requests.get(f"https://api.umd.io/v1/courses/{course_name}").json()
+
+            if isinstance(umdio_course, dict) and "error_code" in umdio_course.keys():
+                return None
+
+            umdio_course = umdio_course[0]
+
+            course = Course.unfiltered.create(
+                name=course_name,
+                department=umdio_course['dept_id'].strip("\n\t\r "),
+                course_number=umdio_course['course_id'].strip("\n\t\r ")[4:],
+                title=umdio_course['name'].strip("\n\t\r "),
+                credits=umdio_course['credits'].strip("\n\t\r "),
+                description=umdio_course["description"].strip("\n\t\r ")
+            )
+
+            self.total_num_new_courses += 1
+
+        return course

--- a/home/management/commands/updatecourses.py
+++ b/home/management/commands/updatecourses.py
@@ -97,12 +97,7 @@ class Command(BaseCommand):
                 for entry in umdio_professor['taught']:
                     semester_taught = Semester(entry['semester'])
                     clean_course_name = entry['course_id'].strip("\n\t\r ")
-
-                    # get a course object or None if umdio
                     course = self.get_or_create_course(clean_course_name)
-
-                    if not course:
-                        continue
 
                     # get all professorcourse entries that match the professor and course
                     professorcourse = self.professor_courses.filter(
@@ -131,15 +126,8 @@ class Command(BaseCommand):
 
         # if we don't have the course...
         if not course:
-            # see if umdio has the course.
-            umdio_course = requests.get(f"https://api.umd.io/v1/courses/{course_name}").json()
-
-            # if umdio doesn't have the course, return None.
-            if isinstance(umdio_course, dict) and "error_code" in umdio_course.keys():
-                return None
-
-            # otherwise, create a new course using the info from umdio
-            umdio_course = umdio_course[0]
+            # create a new course using the course info from umdio
+            umdio_course = requests.get(f"https://api.umd.io/v1/courses/{course_name}").json()[0]
 
             course = Course.unfiltered.create(
                 name=course_name,

--- a/home/management/commands/updatecourses.py
+++ b/home/management/commands/updatecourses.py
@@ -97,11 +97,14 @@ class Command(BaseCommand):
                 for entry in umdio_professor['taught']:
                     semester_taught = Semester(entry['semester'])
                     clean_course_name = entry['course_id'].strip("\n\t\r ")
+
+                    # get a course object or None if umdio
                     course = self.get_or_create_course(clean_course_name)
 
                     if not course:
                         continue
 
+                    # get all professorcourse entries that match the professor and course
                     professorcourse = self.professor_courses.filter(
                         course=course,
                         professor=professor
@@ -123,14 +126,19 @@ class Command(BaseCommand):
             umdio_professors = requests.get("https://api.umd.io/v1/professors", params=kwargs).json()
 
     def get_or_create_course(self, course_name):
+        # get the course if we have the course
         course = Course.unfiltered.filter(name=course_name).first()
 
+        # if we don't have the course...
         if not course:
+            # see if umdio has the course.
             umdio_course = requests.get(f"https://api.umd.io/v1/courses/{course_name}").json()
 
+            # if umdio doesn't have the course, return None.
             if isinstance(umdio_course, dict) and "error_code" in umdio_course.keys():
                 return None
 
+            # otherwise, create a new course using the info from umdio
             umdio_course = umdio_course[0]
 
             course = Course.unfiltered.create(

--- a/home/management/commands/updatecourses.py
+++ b/home/management/commands/updatecourses.py
@@ -37,14 +37,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         t_start = datetime.now()
-        self._professors()
+        self.update_professors_and_courses()
 
         print(f"\n** New Courses Created: {self.total_num_new_courses} **")
         print(f"** New Professors Created: {self.total_num_new_professors} **")
         runtime = datetime.now() - t_start
         print(f"Runtime: {round(runtime.seconds / 60, 2)} minutes")
 
-    def _professors(self):
+    def update_professors_and_courses(self):
         kwargs = {"per_page": 100, "page": 1}
         umdio_professors = requests.get("https://api.umd.io/v1/professors", params=kwargs).json()
 


### PR DESCRIPTION
I know what you're thinking: more changes to the courseupdate script?! Really?
That's ok. These changes are the final changes because this pr actually enables this script to do what it should've done all along. Here's everything this pr changes from the script we knew and loved:
- removed semester argument 
- iterate through professors (via umdio's professors/ endpoint) and add a ProfessorCourse relationship for *all* courses that a professor taught during *any* semester. Previously, a course would only be created if it was taught by the professor during the semester specified as a command-line argument and the _only_ ProfessorCourse relationship to be added would be the one during the specified semester. This created pending professors with no courses which either made it difficult to disambiguate with similar professors or meant that we'd verify a professor with no courses (that's gross).
- NOTE: this script now goes through all the professors on umdio's api but the time to run the script has gone down _substantially_ to under 6 minutes. There's a bunch of reasons why this is the case but I won't go into those here unless someone is curious. 
