### PR TITLE
Incorporate initial fixture into migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,9 @@ The other fields can be left alone for now. We'll discuss the `WEBHOOK_*` and `E
 Once you're satisfied with your config, continue with your setup:
 
 ```bash
+# this command will take a while to run because it imports some
+# initial data.
 python manage.py migrate
-# for testing, we provide some initial data, including all grades,
-# professors, courses, and reviews on the live site (as of 01/20/2022).
-# If you'd prefer to start from scratch with a fresh database, you can
-# safely skip this step, but we recommend it for anyone looking to develop
-# planetterp.
-# This command will take a while (about 15 minutes) to run.
-python manage.py loaddata home/fixtures/initial
 # courses which have been taught in the past 10 years are considered "recent".
 # courses which are not recent are hidden from some displays like search
 # and courses taught. Calculating whether a course is recent can be very

--- a/home/migrations/0010_initial_data.py
+++ b/home/migrations/0010_initial_data.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+from django.core.serializers import base, python
+from django.core.management import call_command
+
+# Loads the initial fixture data as a fixed point in our migration chain. See
+# https://github.com/planetterp/PlanetTerp/pull/114 for why this cannot be a
+# normal loaddata call.
+
+# ugly monkey patching to make loaddata use models at the time of migration,
+# instead of the model schema defined by the current source files.
+# This code has remained unchanged since django 1.8, so I think it's safe to
+# consider it stable, although it is absolutely not part of the public django
+# api.
+# https://stackoverflow.com/a/39743581
+def load_fixture(apps, _schema_editor):
+    old_get_model = python._get_model
+
+    def _get_model(model_identifier):
+        try:
+            return apps.get_model(model_identifier)
+        except (LookupError, TypeError):
+            raise base.DeserializationError("Invalid model identifier: "
+                f"'{model_identifier}'")
+
+    python._get_model = _get_model
+
+    try:
+        call_command('loaddata', 'home/fixtures/initial.json.gz')
+    finally:
+        python._get_model = old_get_model
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('home', '0009_auto_20230310_0939')
+    ]
+
+    operations = [
+        migrations.RunPython(load_fixture)
+    ]


### PR DESCRIPTION
tldr: fix migrations not working, for good.

Using data instead of a data migration in the first place was poor planning on my part. It turns out that loading fixtures uses the schema of current model objects. This means that if you create a fixture on commit A, modify the schema - say, renaming a field - and try to load the same fixture in commit B, it will try to use the schema in B for the data in A. This conflicts.

I've updated our fixture to the current schema and added a migration to import this fixture. The important difference here is the migration uses the models *at the time of the migration*, which matches the fixtures models. Because this migration is a fixed point in the migration chain, it will not be affected by future migrations.

This required some ugly monkey-patching. It's certainly not ideal, but it's the best solution I've got.