### PR TITLE
start statistics graphs at 0

### DIFF
--- a/home/templates/statistics.html
+++ b/home/templates/statistics.html
@@ -45,6 +45,9 @@ const reviewRatingChart = new Chart(reviewRatingGraph, {
 					display: true,
 					labelString: "Count"
 				},
+				ticks: {
+					beginAtZero: true
+				}
 			}]
         },
 		legend: {
@@ -91,6 +94,9 @@ const reviewDateChart = new Chart(reviewDateGraph, {
 					display: true,
 					labelString: "Count"
 				},
+				ticks: {
+					beginAtZero: true
+				}
 			}]
         },
 		legend: {
@@ -120,6 +126,9 @@ const professorRatingsChart = new Chart(professorRatingsGraph, {
 					display: true,
 					labelString: "Count"
 				},
+				ticks: {
+					beginAtZero: true
+				}
 			}]
 		},
 		legend: {


### PR DESCRIPTION
before:
<img width="1003" alt="image" src="https://github.com/planetterp/PlanetTerp/assets/31628143/0be1c5a1-b229-454d-bd03-694792c2d583">


after:

<img width="984" alt="image" src="https://github.com/planetterp/PlanetTerp/assets/31628143/7f83605f-8d60-45ca-af77-4243b214d290">


only currently affects the review count graph, but I've applied it to all graphs for future-proofing.