### PR TITLE
open "not sure what to write" tip in a new tab

### DIFF
--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -152,7 +152,7 @@ class ProfessorForm(Form):
                 Div(
                     content,
                     anonymous,
-                    HTML(f'<a href="{reverse("about")}#tips" style="float:right; font-size:15px">Not sure what to write?</a>'),
+                    HTML(f'<a href="{reverse("about")}#tips" target="_blank" style="float:right; font-size:15px">Not sure what to write?</a>'),
                     content_errors,
                     css_id=f"review-right-wrapper-{self.form_type.value}",
                     css_class="review-right-wrapper"


### PR DESCRIPTION
Someone may click this in the middle of their review expecting it to open a modal, or some other non-destructive action. Instead, it currently navigates to a new page and any progress on their review is lost. We shouldn't be making it easy for users to lose their reviews like this.

It would also be nice to store unsubmitted user reviews in localstorage so they are recoverable even if the tab is closed, but that's for another day.