### PR TITLE
add admin permission, move from is_staff to permission system

### DIFF
--- a/home/migrations/0011_user_is_planetterp_admin.py
+++ b/home/migrations/0011_user_is_planetterp_admin.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('home', '0010_initial_data'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='user',
+            options={'permissions': [('admin', 'Can take any planetterp admin actions')]},
+        ),
+    ]

--- a/home/migrations/0011_user_is_planetterp_admin.py
+++ b/home/migrations/0011_user_is_planetterp_admin.py
@@ -10,6 +10,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterModelOptions(
             name='user',
-            options={'permissions': [('admin', 'Can take any planetterp admin actions')]},
+            options={'permissions': [('mod', 'Can take any planetterp site moderator actions')]},
         ),
     ]

--- a/home/models.py
+++ b/home/models.py
@@ -381,7 +381,7 @@ class User(AbstractUser):
         # to the prod db, which the django admin panel grants to a moderate
         # degree.
         permissions = [
-            ("admin", "Can take any planetterp admin actions")
+            ("mod", "Can take any planetterp site moderator actions")
         ]
 
     # Workaround to force CharField to store empty values as NULL instead of ''

--- a/home/models.py
+++ b/home/models.py
@@ -331,11 +331,9 @@ class User(AbstractUser):
     objects = UserManager()
 
     send_review_email = BooleanField(default=True)
-
     # accounts which are from ourumd are given an unusable password so nobody
     # can log in to the accounts
     from_ourumd = BooleanField(default=False)
-
     username = CharField(
         max_length=22,
         unique=True,
@@ -351,7 +349,6 @@ class User(AbstractUser):
             "unique": "A user with that username already exists."
         }
     )
-
     email = EmailField(
         unique=True,
         null=True,
@@ -366,7 +363,6 @@ class User(AbstractUser):
                 )
         }
     )
-
     password = CharField(
         max_length=128,
         validators=[
@@ -376,6 +372,17 @@ class User(AbstractUser):
             "required": "You must enter a password"
         }
     )
+
+    class Meta:
+        # planetterp admins are a level between staff users and normal users:
+        # admins can view the admin panel and take all actions theiren, but
+        # cannot view the django admin panel.
+        # Essentially, this role is for site admins which should not have access
+        # to the prod db, which the django admin panel grants to a moderate
+        # degree.
+        permissions = [
+            ("admin", "Can take any planetterp admin actions")
+        ]
 
     # Workaround to force CharField to store empty values as NULL instead of ''
     # https://stackoverflow.com/a/38621160

--- a/home/tables/columns.py
+++ b/home/tables/columns.py
@@ -45,7 +45,7 @@ class InformationColumn(tables.Column):
 
     def render(self, value: dict):
         review = value.pop("review")
-        is_staff = value.pop("is_staff")
+        is_planetterp_admin = value.pop("is_planetterp_admin")
 
         column_html = ""
         if review.professor.slug:
@@ -80,7 +80,7 @@ class InformationColumn(tables.Column):
 
         # wrap long usernames to avoid increasing the information column width
         column_html += '<span style="white-space: normal; word-break: break-all;">'
-        if is_staff and review.user:
+        if is_planetterp_admin and review.user:
             if review.anonymous:
                 column_html += '''
                      <span class="noselect" data-toggle="tooltip" data-placement="right" title="This reviewer posted anonymously">
@@ -110,12 +110,12 @@ class InformationColumn(tables.Column):
         if review.created_at.date() >= date(2020, 3, 10) and review.created_at.date() <= date(2021, 8, 30):
             column_html += ' <i class="fas fa-head-side-mask" data-toggle="tooltip" data-placement="right" title="This review was submitted while most classes were online during the COVID-19 pandemic. It may not be indicative of a regular semester."></i>'
 
-        if not review.user or (review.anonymous and not is_staff):
+        if not review.user or (review.anonymous and not is_planetterp_admin):
             username = "Anonymous"
         else:
             username = review.user.username
 
-        if is_staff:
+        if is_planetterp_admin:
             column_html += '''
                 <br/ >
                 <span>

--- a/home/tables/reviews_table.py
+++ b/home/tables/reviews_table.py
@@ -59,7 +59,7 @@ class BaseReviewsTable(tables.Table):
             if ReviewsTableColumn.INFORMATION in self.columns:
                 formatted_data['information'] = {
                     "review": review,
-                    "is_planetterp_admin": self.request.user.has_perm("home.admin")
+                    "is_planetterp_admin": self.request.user.has_perm("home.mod")
                 }
             if ReviewsTableColumn.REVIEW in self.columns:
                 formatted_data['review'] = {"review": review}
@@ -87,7 +87,7 @@ class VerifiedReviewsTable(BaseReviewsTable):
         )
 
         self.columns = [ReviewsTableColumn.INFORMATION, ReviewsTableColumn.REVIEW]
-        if request.user.has_perm("home.admin"):
+        if request.user.has_perm("home.mod"):
             self.columns.append(ReviewsTableColumn.ACTION)
 
         kwargs = {"empty_text": empty_text}

--- a/home/tables/reviews_table.py
+++ b/home/tables/reviews_table.py
@@ -59,7 +59,7 @@ class BaseReviewsTable(tables.Table):
             if ReviewsTableColumn.INFORMATION in self.columns:
                 formatted_data['information'] = {
                     "review": review,
-                    "is_staff": self.request.user.is_staff
+                    "is_planetterp_admin": self.request.user.has_perm("home.admin")
                 }
             if ReviewsTableColumn.REVIEW in self.columns:
                 formatted_data['review'] = {"review": review}
@@ -87,7 +87,7 @@ class VerifiedReviewsTable(BaseReviewsTable):
         )
 
         self.columns = [ReviewsTableColumn.INFORMATION, ReviewsTableColumn.REVIEW]
-        if request.user.is_staff:
+        if request.user.has_perm("home.admin"):
             self.columns.append(ReviewsTableColumn.ACTION)
 
         kwargs = {"empty_text": empty_text}

--- a/home/templates/base_main.html
+++ b/home/templates/base_main.html
@@ -33,7 +33,7 @@
         <link rel="stylesheet" type="text/css" href="{% static 'css/progressbar.css' %}">
         <link rel="stylesheet" type="text/css" href="{% static 'fontawesome-5.15.3/css/all.min.css' %}">
 
-        {% if user and perms.home.admin %}
+        {% if user and perms.home.mod %}
             <script type="text/javascript" src="{% static 'js/admin-action.js' %}"></script>
         {% endif %}
 
@@ -151,7 +151,7 @@
                         </ul>
 
                         <ul class="navbar-nav navbar-right mr-3">
-                            {% if perms.home.admin %}
+                            {% if perms.home.mod %}
                                 <li class="nav-item">
                                     <a style="color: #ffc107;" class="nav-link" href="{% url 'admin' %}#reviews" title="Admin Page">
                                         <span id="unverified_count" class="badge badge-pill badge-warning">{% unverified_count %}</span>

--- a/home/templates/base_main.html
+++ b/home/templates/base_main.html
@@ -33,7 +33,7 @@
         <link rel="stylesheet" type="text/css" href="{% static 'css/progressbar.css' %}">
         <link rel="stylesheet" type="text/css" href="{% static 'fontawesome-5.15.3/css/all.min.css' %}">
 
-        {% if user and user.is_staff %}
+        {% if user and perms.home.admin %}
             <script type="text/javascript" src="{% static 'js/admin-action.js' %}"></script>
         {% endif %}
 
@@ -151,7 +151,7 @@
                         </ul>
 
                         <ul class="navbar-nav navbar-right mr-3">
-                            {% if user.is_staff %}
+                            {% if perms.home.admin %}
                                 <li class="nav-item">
                                     <a style="color: #ffc107;" class="nav-link" href="{% url 'admin' %}#reviews" title="Admin Page">
                                         <span id="unverified_count" class="badge badge-pill badge-warning">{% unverified_count %}</span>

--- a/home/templates/index.html
+++ b/home/templates/index.html
@@ -90,7 +90,7 @@
 							django can't handle parenthesis in if statements for order of operations :/ so
 							split into multiple cases
 						 -->
-						{% if user.is_staff and review.user %}
+						{% if perms.home.admin and review.user %}
 							{{ review.user.username }}
 						{% elif review.user and not review.anonymous %}
 							{{ review.user.username }}

--- a/home/templates/index.html
+++ b/home/templates/index.html
@@ -90,7 +90,7 @@
 							django can't handle parenthesis in if statements for order of operations :/ so
 							split into multiple cases
 						 -->
-						{% if perms.home.admin and review.user %}
+						{% if perms.home.mod and review.user %}
 							{{ review.user.username }}
 						{% elif review.user and not review.anonymous %}
 							{{ review.user.username }}

--- a/home/templates/professor.html
+++ b/home/templates/professor.html
@@ -20,7 +20,7 @@
 <div class="container mw-100 px-5">
 	<div class="row">
 		<div class="col-xs-12 col-sm-6 col-md-6 offset-md-1">
-			{% if perms.home.admin %}
+			{% if perms.home.mod %}
 				<div class="professor-header input-group">
 					<h1 class="input-group">
 						<span id="professor-name"><strong>{{ professor.name }}</strong></span>
@@ -130,7 +130,7 @@
 <script type="text/javascript">
 	var num_reviews = parseInt("{{ num_reviews }}");
 	var average_rating = {% if professor.average_rating %} {{ professor.average_rating }} {% else %} null {% endif %};
-	var is_admin = {{ perms.home.admin|yesno:"true,false" }};
+	var is_mod = {{ perms.home.mod|yesno:"true,false" }};
 
 	$(function() {
 		initializeRateYo(3, "review");
@@ -141,7 +141,7 @@
 			generateProfessorStats();
 		}
 
-		if (is_admin) {
+		if (is_mod) {
 			initalizeAutoComplete('{{ csrf_token }}');
 		}
 	});

--- a/home/templates/professor.html
+++ b/home/templates/professor.html
@@ -20,7 +20,7 @@
 <div class="container mw-100 px-5">
 	<div class="row">
 		<div class="col-xs-12 col-sm-6 col-md-6 offset-md-1">
-			{% if user.is_staff %}
+			{% if perms.home.admin %}
 				<div class="professor-header input-group">
 					<h1 class="input-group">
 						<span id="professor-name"><strong>{{ professor.name }}</strong></span>
@@ -130,7 +130,7 @@
 <script type="text/javascript">
 	var num_reviews = parseInt("{{ num_reviews }}");
 	var average_rating = {% if professor.average_rating %} {{ professor.average_rating }} {% else %} null {% endif %};
-	var is_admin = {{ user.is_staff|yesno:"true,false" }};
+	var is_admin = {{ perms.home.admin|yesno:"true,false" }};
 
 	$(function() {
 		initializeRateYo(3, "review");

--- a/home/views/admin.py
+++ b/home/views/admin.py
@@ -5,7 +5,7 @@ from django.shortcuts import render
 from django.views import View
 from django.http import JsonResponse
 from django.template.context_processors import csrf
-from django.contrib.auth.mixins import UserPassesTestMixin
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
@@ -21,10 +21,8 @@ from home.forms.admin_forms import (ProfessorMergeForm, ProfessorSlugForm,
 from home.utils import send_email, _ttl_cache
 from planetterp import config
 
-class Admin(UserPassesTestMixin, View):
-
-    def test_func(self):
-        return self.request.user.is_staff
+class Admin(PermissionRequiredMixin, View):
+    permission_required = "home.admin"
 
     def get(self, request):
         reviews = (

--- a/home/views/admin.py
+++ b/home/views/admin.py
@@ -22,7 +22,7 @@ from home.utils import send_email, _ttl_cache
 from planetterp import config
 
 class Admin(PermissionRequiredMixin, View):
-    permission_required = "home.admin"
+    permission_required = "home.mod"
 
     def get(self, request):
         reviews = (

--- a/home/views/basic.py
+++ b/home/views/basic.py
@@ -129,7 +129,7 @@ class SortReviewsTable(View):
         return JsonResponse(context)
 
 class RecomputeTTLCache(PermissionRequiredMixin, View):
-    permission_required = "home.admin"
+    permission_required = "home.mod"
 
     def post(self, _request):
         recompute_ttl_cache()
@@ -141,7 +141,7 @@ class UserProfile(PermissionRequiredMixin, View):
     #
     # We may want to allow people to view a subset of other user's profiles
     # in the future, which would show only the public reviews of that user.
-    permission_required = "home.admin"
+    permission_required = "home.mod"
 
     def get(self, request, user_id):
         # if a user clicks on a link to their own profile, redirect them to

--- a/home/views/basic.py
+++ b/home/views/basic.py
@@ -3,7 +3,7 @@ from django.shortcuts import redirect, render
 from django.views import View
 from django.views.generic import TemplateView, RedirectView, ListView
 from django.http import HttpResponse, Http404
-from django.contrib.auth.mixins import UserPassesTestMixin
+from django.contrib.auth.mixins import PermissionRequiredMixin
 
 from home.models import Organization, Professor, Course, Review, Grade, User
 from home.tables.reviews_table import VerifiedReviewsTable, ProfileReviewsTable
@@ -128,22 +128,20 @@ class SortReviewsTable(View):
 
         return JsonResponse(context)
 
-class RecomputeTTLCache(UserPassesTestMixin, View):
-    def test_func(self):
-        return self.request.user.is_staff
+class RecomputeTTLCache(PermissionRequiredMixin, View):
+    permission_required = "home.admin"
 
     def post(self, _request):
         recompute_ttl_cache()
         return HttpResponse()
 
-class UserProfile(UserPassesTestMixin, View):
+class UserProfile(PermissionRequiredMixin, View):
     # as all accounts have the option to still leave anonymous reviews, only
     # allow admins to view individual user profiles for now.
     #
     # We may want to allow people to view a subset of other user's profiles
     # in the future, which would show only the public reviews of that user.
-    def test_func(self):
-        return self.request.user.is_staff
+    permission_required = "home.admin"
 
     def get(self, request, user_id):
         # if a user clicks on a link to their own profile, redirect them to

--- a/home/views/endpoints.py
+++ b/home/views/endpoints.py
@@ -25,7 +25,7 @@ class Autocomplete(View):
                 value_dict['name'] = result.name
 
             data = {
-                "label": f"{result}" if request.user.is_staff else f"{result.name}",
+                "label": f"{result}" if request.user.has_perm("home.admin") else f"{result.name}",
                 "result": value_dict
             }
 

--- a/home/views/endpoints.py
+++ b/home/views/endpoints.py
@@ -25,7 +25,7 @@ class Autocomplete(View):
                 value_dict['name'] = result.name
 
             data = {
-                "label": f"{result}" if request.user.has_perm("home.admin") else f"{result.name}",
+                "label": f"{result}" if request.user.has_perm("home.mod") else f"{result.name}",
                 "result": value_dict
             }
 

--- a/home/views/professor.py
+++ b/home/views/professor.py
@@ -68,7 +68,7 @@ class Professor(View):
             "num_reviews": reviews.count()
         }
 
-        if request.user.has_perm("home.admin"):
+        if request.user.has_perm("home.mod"):
             edit_professor_form = ProfessorUpdateForm(professor, instance=professor)
             unverify_professor_form = ProfessorUnverifyForm(professor.pk)
             merge_professor_form = ProfessorMergeForm(request)

--- a/home/views/professor.py
+++ b/home/views/professor.py
@@ -68,7 +68,7 @@ class Professor(View):
             "num_reviews": reviews.count()
         }
 
-        if request.user.is_staff:
+        if request.user.has_perm("home.admin"):
             edit_professor_form = ProfessorUpdateForm(professor, instance=professor)
             unverify_professor_form = ProfessorUnverifyForm(professor.pk)
             merge_professor_form = ProfessorMergeForm(request)


### PR DESCRIPTION
See inline comment for details:

```python
        # planetterp admins are a level between staff users and normal users:
        # admins can view the admin panel and take all actions theiren, but
        # cannot view the django admin panel.
        # Essentially, this role is for site admins which should not have access
        # to the prod db, which the django admin panel grants to a moderate
        # degree.
```

I did try adding a `User.is_planetterp_admin` field first, but ran into issues with `request.user.is_planetterp_admin` erroring when `type(user) is AnonymousUser`. This wasn't an issue with `request.user.is_staff` because `is_staff` is a builtin field on `AbstractUser`, while we only set `is_planetterp_admin` on our own `User : AbstractUser`. Frankly, this seems like bad design by django.

Not happy about using the django permissions system - it has its own warts[^1] - but it seemed the easiest and most flexible way to achieve this. 

All current staff accounts are also superusers, which have every permission automatically, so there's no need to do anything on the migration side of things. 

To assign this permission, use the django admin panel.

[^1]: permissions are inherently tied to a model, so there's no way to declare a site-wide permission like "is an admin". The next best place for it to live is under the `User` model, which looks strange. Nothing breaks, but it's counterintuitive when adding permissions to users.