### PR TITLE
Remove unused imports

### DIFF
--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -11,11 +11,8 @@ from django.utils.html import format_html
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Fieldset, Layout, Div, Field, HTML, Button
 from crispy_forms.bootstrap import FormActions, Alert, InlineRadios, Modal
-from discord_webhook import DiscordWebhook
-from discord_webhook.webhook import DiscordEmbed
 
 from home.models import Review, Professor, Course
-from planetterp import config
 
 # Base form that contains common form fields
 class ProfessorForm(Form):

--- a/home/views/admin.py
+++ b/home/views/admin.py
@@ -7,7 +7,6 @@ from django.http import JsonResponse
 from django.template.context_processors import csrf
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.urls import reverse
-from django.utils.safestring import mark_safe
 
 from crispy_forms.utils import render_crispy_form
 from discord_webhook import DiscordWebhook, DiscordEmbed


### PR DESCRIPTION
closes #138
I remove unused/unnecessary imports in any Python file. I found one import in `home\middleware\__init__.py` that seems to be unused but being in an `__init__.py` file it's more important than it seems. I also left the auto generated import in the `test.py` file although the file is empty.