### PR TITLE
Render 404 on missing autocomplete query and geneds 

### DIFF
--- a/home/views/data_sources.py
+++ b/home/views/data_sources.py
@@ -2,6 +2,7 @@ from django.http import JsonResponse
 from django.db.models import Sum
 from django.views import View
 from django.urls import reverse
+from django.shortcuts import render
 
 from home.models import Professor, Grade, Course, Gened
 from home.utils import ttl_cache, Semester
@@ -234,6 +235,9 @@ class CourseDifficultyData(View):
 
 class GenedData(View):
     def get(self, request):
+        if "geneds" not in request.GET:
+            return render(request, "404.html")
+        
         geneds = request.GET["geneds"].replace("&", "").split("=on")
         geneds = set(gened for gened in geneds if gened in Gened.GENEDS)
 

--- a/home/views/data_sources.py
+++ b/home/views/data_sources.py
@@ -1,8 +1,8 @@
 from django.http import JsonResponse
 from django.db.models import Sum
+from django.http import Http404
 from django.views import View
 from django.urls import reverse
-from django.shortcuts import render
 
 from home.models import Professor, Grade, Course, Gened
 from home.utils import ttl_cache, Semester
@@ -236,7 +236,7 @@ class CourseDifficultyData(View):
 class GenedData(View):
     def get(self, request):
         if "geneds" not in request.GET:
-            return render(request, "404.html")
+            raise Http404()
         
         geneds = request.GET["geneds"].replace("&", "").split("=on")
         geneds = set(gened for gened in geneds if gened in Gened.GENEDS)

--- a/home/views/endpoints.py
+++ b/home/views/endpoints.py
@@ -1,11 +1,16 @@
 from django.http import JsonResponse
 from django.views import View
+from django.shortcuts import render
 
 from home import queries
 
 class Autocomplete(View):
     def get(self, request):
         data = request.GET
+        
+        if "query" not in data:
+            return render(request, "404.html")
+        
         query = data["query"]
         types = data.getlist("types[]")
         professors = "professor" in types

--- a/home/views/endpoints.py
+++ b/home/views/endpoints.py
@@ -1,6 +1,7 @@
 from django.http import JsonResponse
 from django.views import View
-from django.shortcuts import render
+# from django.shortcuts import render
+from django.http import Http404
 
 from home import queries
 
@@ -9,7 +10,8 @@ class Autocomplete(View):
         data = request.GET
         
         if "query" not in data:
-            return render(request, "404.html")
+            # return render(request, "404.html")
+            raise Http404()
         
         query = data["query"]
         types = data.getlist("types[]")

--- a/home/views/endpoints.py
+++ b/home/views/endpoints.py
@@ -1,6 +1,5 @@
 from django.http import JsonResponse
 from django.views import View
-# from django.shortcuts import render
 from django.http import Http404
 
 from home import queries
@@ -10,7 +9,6 @@ class Autocomplete(View):
         data = request.GET
         
         if "query" not in data:
-            # return render(request, "404.html")
             raise Http404()
         
         query = data["query"]


### PR DESCRIPTION
Issues mentioned on the discord server. Rendering a 404 template if the `query` in the `AutoComplete` view is missing and if `geneds` in the `GenedData` view is missing.