### PR TITLE
Make reviews anonymous by default

### DIFF
--- a/home/forms/professor_forms.py
+++ b/home/forms/professor_forms.py
@@ -51,7 +51,8 @@ class ProfessorForm(Form):
     anonymous = BooleanField(
         required=False,
         widget=CheckboxInput,
-        label="Post Anonymously"
+        label="Post Anonymously",
+        initial=True
     )
 
     def __init__(self, user: QuerySet, form_type: Review.ReviewType, **kwargs):


### PR DESCRIPTION
Currently, when an authenticated user writes a review, the default is that the review is not anonymous. 

<img width="1107" alt="image" src="https://github.com/planetterp/PlanetTerp/assets/102197130/2f150437-3e4e-4fc1-8ed9-03d32589220f">

I think it is better to default to an anonymous review. It's no big deal if a review is unintentionally anonymous. It is an issue if the review unintentionally has the username visible.