### PR TITLE
code regex more strict to reduce false positive matches that need db query

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -200,7 +200,7 @@ class Course(Model):
     recent = RecentCourseManager()
     unfiltered = Manager()
 
-    course_code_format = '[A-Za-z]{4}(?:[A-Za-z]|[0-9]){3,6}'
+    course_code_format = '[A-Za-z]{4}(?:[0-9]){3,6}'
 
     def save(self, *args, **kwargs):
         # `name` is essentially a computed field, and will never have a value


### PR DESCRIPTION
This created a decent speed up in my local environment - page is loading almost immediately.

By make the course code regex more restrictive, we'll miss linking a few course but reduce the number of false positives which are causing many of the queries.