### PR TITLE
Homepage search whitespace fix

### DIFF
--- a/home/views/search.py
+++ b/home/views/search.py
@@ -1,3 +1,5 @@
+import re
+
 from django.shortcuts import redirect, render
 from django.views import View
 from django.http import HttpResponse
@@ -13,6 +15,7 @@ class Search(View):
             return HttpResponse("Invalid search query.")
 
         query = data["query"]
+        query = re.sub(r"\s+", " ", query).strip()
 
         if query == "":
             context = {"results": []}

--- a/home/views/search.py
+++ b/home/views/search.py
@@ -15,7 +15,6 @@ class Search(View):
             return HttpResponse("Invalid search query.")
 
         query = data["query"]
-        query = re.sub(r"\s+", " ", query).strip()
 
         if query == "":
             context = {"results": []}
@@ -23,6 +22,8 @@ class Search(View):
 
         if any(character.isdigit() for character in query):
             query = query.replace(" ", "")
+
+        query = re.sub(r"\s+", " ", query).strip()
 
         results = queries.search(query, 30, courses=True, professors=True)
 


### PR DESCRIPTION
Follows up on #143 and addresses #165.

To reproduce failed queries:
- `  Tony Barber  ` (or https://planetterp.com/search?query=+Tony+Barber+)
- `  Tony   Barber   ` (or https://planetterp.com/search?query=++Tony+++Barber+++)

This change trims trailing whitespace and collapses multiple spaces into a single space within the main homepage search query.
